### PR TITLE
[Phase 1] Create Strategy Registry (#7)

### DIFF
--- a/src/alpacalyzer/cli.py
+++ b/src/alpacalyzer/cli.py
@@ -53,6 +53,7 @@ def main():  # pragma: no cover
     parser.add_argument("--tickers", type=str, help="Comma-separated list of tickers to analyze (e.g., AAPL,MSFT,GOOG)")
     parser.add_argument("--agents", type=str, default="ALL", help="Comma-separated list of agents to use (e.g., ALL,TRADE,INVEST)")
     parser.add_argument("--ignore-market-status", action="store_true", help="Ignore market status and trade at any time")
+    parser.add_argument("--strategy", type=str, help="Trading strategy to use from registry (e.g., momentum, breakout)")
     # EOD analyzer options
     parser.add_argument("--eod-analyze", action="store_true", help="Run End-of-Day analyzer and exit")
     parser.add_argument("--eod-date", type=str, help="EET date (YYYY-MM-DD) to analyze; defaults to today")

--- a/src/alpacalyzer/strategies/__init__.py
+++ b/src/alpacalyzer/strategies/__init__.py
@@ -23,6 +23,7 @@ from alpacalyzer.strategies.base import (
     Strategy,
 )
 from alpacalyzer.strategies.config import StrategyConfig
+from alpacalyzer.strategies.registry import StrategyRegistry
 
 __all__ = [
     "BaseStrategy",
@@ -31,4 +32,5 @@ __all__ = [
     "ExitDecision",
     "MarketContext",
     "StrategyConfig",
+    "StrategyRegistry",
 ]

--- a/src/alpacalyzer/strategies/registry.py
+++ b/src/alpacalyzer/strategies/registry.py
@@ -1,0 +1,154 @@
+"""
+Strategy registry for managing available trading strategies.
+
+This module provides a centralized registry for registering and retrieving
+strategy implementations. It supports:
+- Registration of strategy classes with optional default configs
+- Strategy instantiation with custom or default configs
+- Instance caching for singleton access (when no custom config)
+- Listing available strategies
+- Auto-registration of built-in strategies
+"""
+
+from typing import TYPE_CHECKING
+
+from alpacalyzer.strategies.base import Strategy
+
+if TYPE_CHECKING:
+    from alpacalyzer.strategies.config import StrategyConfig
+else:
+    # Avoid circular import at runtime
+    from alpacalyzer.strategies.config import StrategyConfig as _Config
+
+    StrategyConfig = _Config
+
+
+class StrategyRegistry:
+    """
+    Registry for available trading strategies.
+
+    The registry maintains three class-level dictionaries:
+    - _strategies: Maps strategy names to their classes
+    - _instances: Caches singleton instances for strategies without custom configs
+    - _default_configs: Stores default configs for each strategy
+
+    Example:
+        >>> StrategyRegistry.register("momentum", MomentumStrategy)
+        >>> strategy = StrategyRegistry.get("momentum")
+        >>> entry_decision = strategy.evaluate_entry(signal, context)
+    """
+
+    _strategies: dict[str, type[Strategy]] = {}
+    _instances: dict[str, Strategy] = {}
+    _default_configs: dict[str, StrategyConfig] = {}
+
+    @classmethod
+    def register(
+        cls,
+        name: str,
+        strategy_class: type[Strategy],
+        default_config: StrategyConfig | None = None,
+    ) -> None:
+        """
+        Register a strategy class with optional default config.
+
+        Args:
+            name: Unique name for the strategy
+            strategy_class: Strategy class implementing Strategy protocol
+            default_config: Optional default configuration for this strategy
+
+        Example:
+            >>> config = StrategyConfig(name="momentum", stop_loss_pct=0.05)
+            >>> StrategyRegistry.register("momentum", MomentumStrategy, config)
+        """
+        cls._strategies[name] = strategy_class
+        if default_config:
+            cls._default_configs[name] = default_config
+
+    @classmethod
+    def get(cls, name: str, config: StrategyConfig | None = None) -> Strategy:
+        """
+        Get or create a strategy instance.
+
+        If no custom config is provided, returns a cached singleton instance.
+        Otherwise, creates a new instance with the provided config.
+
+        Args:
+            name: Name of the registered strategy
+            config: Optional custom configuration (uses default if None)
+
+        Returns:
+            Strategy instance
+
+        Raises:
+            ValueError: If strategy name is not registered
+
+        Example:
+            >>> # Get with default config (cached)
+            >>> strategy = StrategyRegistry.get("momentum")
+            >>>
+            >>> # Get with custom config (new instance)
+            >>> custom_config = StrategyConfig(stop_loss_pct=0.10)
+            >>> strategy = StrategyRegistry.get("momentum", config=custom_config)
+        """
+        if name not in cls._strategies:
+            raise ValueError(f"Unknown strategy: {name}. Available: {cls.list_strategies()}")
+
+        # Return cached instance if no custom config
+        if config is None and name in cls._instances:
+            return cls._instances[name]
+
+        # Create new instance
+        use_config = config or cls._default_configs.get(name)
+        instance = cls._strategies[name](use_config)
+
+        # Cache instance if no custom config was provided
+        if config is None:
+            cls._instances[name] = instance
+
+        return instance
+
+    @classmethod
+    def list_strategies(cls) -> list[str]:
+        """
+        List all registered strategy names.
+
+        Returns:
+            List of strategy names in registration order (sorted for consistency)
+        """
+        return sorted(cls._strategies.keys())
+
+    @classmethod
+    def get_default_config(cls, name: str) -> StrategyConfig | None:
+        """
+        Get the default config for a registered strategy.
+
+        Args:
+            name: Name of the registered strategy
+
+        Returns:
+            Default StrategyConfig if set, None otherwise
+        """
+        return cls._default_configs.get(name)
+
+
+def _register_builtins() -> None:
+    """
+    Auto-register built-in strategies on module import.
+
+    This function is called when the registry module is imported.
+    It imports and registers all built-in strategies.
+
+    Note: MomentumStrategy will be registered in issue #8.
+    Additional strategies (breakout, mean_reversion, etc.) will be added later.
+    """
+    # Import and register built-in strategies here
+    # from alpacalyzer.strategies.momentum import MomentumStrategy
+    # StrategyRegistry.register("momentum", MomentumStrategy)
+
+    # Future: breakout, mean_reversion, scalping, etc.
+    pass
+
+
+# Auto-register built-in strategies on import
+_register_builtins()

--- a/tests/test_strategy_registry.py
+++ b/tests/test_strategy_registry.py
@@ -1,0 +1,212 @@
+"""
+Tests for StrategyRegistry.
+
+Tests cover:
+- Registering strategies
+- Retrieving strategies by name
+- Instance caching for singleton access
+- Custom config handling
+- Error handling for unknown strategies
+- Listing available strategies
+"""
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from alpacalyzer.strategies.base import BaseStrategy, EntryDecision, ExitDecision, MarketContext
+from alpacalyzer.strategies.config import StrategyConfig
+
+if TYPE_CHECKING:
+    from alpacalyzer.analysis.technical_analysis import TradingSignals
+else:
+    # Runtime: use dict as fallback
+    TradingSignals = dict
+
+from alpacalyzer.strategies.registry import StrategyRegistry
+
+
+class MockStrategy(BaseStrategy):
+    """Mock strategy for testing."""
+
+    def __init__(self, config: StrategyConfig | None = None):
+        self.config = config or StrategyConfig()
+
+    def evaluate_entry(
+        self,
+        signal: TradingSignals,
+        context: MarketContext,
+        agent_recommendation: object = None,
+    ) -> EntryDecision:
+        return EntryDecision(should_enter=False, reason="Mock strategy")
+
+    def evaluate_exit(
+        self,
+        position: object,
+        signal: TradingSignals,
+        context: MarketContext,
+    ) -> ExitDecision:
+        return ExitDecision(should_exit=False, reason="Mock strategy")
+
+
+class TestStrategyRegistry:
+    """Test suite for StrategyRegistry."""
+
+    def setup_method(self):
+        """Clear registry before each test."""
+        StrategyRegistry._strategies.clear()
+        StrategyRegistry._instances.clear()
+        StrategyRegistry._default_configs.clear()
+
+    def test_register_strategy(self):
+        """Test registering a strategy class."""
+        StrategyRegistry.register("test", MockStrategy)
+
+        assert "test" in StrategyRegistry._strategies
+        assert StrategyRegistry._strategies["test"] is MockStrategy
+
+    def test_register_strategy_with_default_config(self):
+        """Test registering a strategy with default config."""
+        config = StrategyConfig(name="test_default", stop_loss_pct=0.05)
+        StrategyRegistry.register("test", MockStrategy, default_config=config)
+
+        assert "test" in StrategyRegistry._strategies
+        assert "test" in StrategyRegistry._default_configs
+        assert StrategyRegistry._default_configs["test"] is config
+
+    def test_get_strategy_without_config(self):
+        """Test getting a strategy instance without custom config."""
+        StrategyRegistry.register("test", MockStrategy)
+        strategy = StrategyRegistry.get("test")
+
+        assert isinstance(strategy, MockStrategy)
+        assert isinstance(strategy.config, StrategyConfig)
+
+    def test_get_strategy_returns_singleton_without_custom_config(self):
+        """Test that get() returns same instance when no custom config."""
+        StrategyRegistry.register("test", MockStrategy)
+        strategy1 = StrategyRegistry.get("test")
+        strategy2 = StrategyRegistry.get("test")
+
+        assert strategy1 is strategy2
+
+    def test_get_strategy_with_custom_config(self):
+        """Test getting a strategy with custom config."""
+        default_config = StrategyConfig(name="default", stop_loss_pct=0.05)
+        custom_config = StrategyConfig(name="custom", stop_loss_pct=0.10)
+
+        StrategyRegistry.register("test", MockStrategy, default_config=default_config)
+
+        strategy_default = StrategyRegistry.get("test")
+        strategy_custom = StrategyRegistry.get("test", config=custom_config)
+
+        # Cast to access config attribute safely
+        assert strategy_default.config.stop_loss_pct == 0.05  # type: ignore[attr-defined]
+        assert strategy_custom.config.stop_loss_pct == 0.10  # type: ignore[attr-defined]
+
+    def test_get_strategy_custom_config_not_cached(self):
+        """Test that custom config creates new instance, not cached."""
+        default_config = StrategyConfig(name="default", stop_loss_pct=0.05)
+        custom_config = StrategyConfig(name="custom", stop_loss_pct=0.10)
+
+        StrategyRegistry.register("test", MockStrategy, default_config=default_config)
+
+        strategy_default = StrategyRegistry.get("test")
+        strategy_custom = StrategyRegistry.get("test", config=custom_config)
+
+        assert strategy_default is not strategy_custom
+        assert strategy_default is StrategyRegistry.get("test")  # Cached instance
+
+    def test_get_unknown_strategy_raises_error(self):
+        """Test that getting unknown strategy raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            StrategyRegistry.get("unknown")
+
+        assert "Unknown strategy: unknown" in str(exc_info.value)
+        assert "Available:" in str(exc_info.value)
+
+    def test_get_strategy_with_no_default_config(self):
+        """Test getting strategy when no default config is registered."""
+        StrategyRegistry.register("test", MockStrategy)
+        strategy = StrategyRegistry.get("test")
+
+        # Should create strategy with None config (or default dataclass)
+        assert isinstance(strategy, MockStrategy)
+
+    def test_list_strategies(self):
+        """Test listing all registered strategies."""
+        StrategyRegistry.register("momentum", MockStrategy)
+        StrategyRegistry.register("breakout", MockStrategy)
+        StrategyRegistry.register("mean_reversion", MockStrategy)
+
+        strategies = StrategyRegistry.list_strategies()
+
+        assert len(strategies) == 3
+        assert "momentum" in strategies
+        assert "breakout" in strategies
+        assert "mean_reversion" in strategies
+
+    def test_list_strategies_empty(self):
+        """Test listing strategies when none registered."""
+        strategies = StrategyRegistry.list_strategies()
+
+        assert strategies == []
+
+    def test_get_default_config(self):
+        """Test getting default config for a strategy."""
+        config = StrategyConfig(name="test", stop_loss_pct=0.05)
+        StrategyRegistry.register("test", MockStrategy, default_config=config)
+
+        default_config = StrategyRegistry.get_default_config("test")
+
+        assert default_config is config
+        assert default_config.stop_loss_pct == 0.05
+
+    def test_get_default_config_none_when_not_set(self):
+        """Test getting default config when none was registered."""
+        StrategyRegistry.register("test", MockStrategy)
+
+        default_config = StrategyRegistry.get_default_config("test")
+
+        assert default_config is None
+
+    def test_multiple_registrations_override(self):
+        """Test that re-registering a strategy overwrites previous."""
+
+        class StrategyA(BaseStrategy):
+            def __init__(self, config=None):
+                self.config = config or StrategyConfig()
+
+            def evaluate_entry(self, signal, context, agent_recommendation=None):
+                return EntryDecision(should_enter=False, reason="A")
+
+            def evaluate_exit(self, position, signal, context):
+                return ExitDecision(should_exit=False, reason="A")
+
+        class StrategyB(BaseStrategy):
+            def __init__(self, config=None):
+                self.config = config or StrategyConfig()
+
+            def evaluate_entry(self, signal, context, agent_recommendation=None):
+                return EntryDecision(should_enter=False, reason="B")
+
+            def evaluate_exit(self, position, signal, context):
+                return ExitDecision(should_exit=False, reason="B")
+
+        StrategyRegistry.register("test", StrategyA)
+        StrategyRegistry.register("test", StrategyB)
+
+        strategy = StrategyRegistry.get("test")
+        entry_decision = strategy.evaluate_entry(
+            {},
+            MarketContext(
+                vix=20.0,
+                market_status="open",
+                account_equity=100000.0,
+                buying_power=100000.0,
+                existing_positions=[],
+                cooldown_tickers=[],
+            ),
+        )
+
+        assert entry_decision.reason == "B"


### PR DESCRIPTION
## Summary

Implements `StrategyRegistry` for managing available trading strategies with registration, retrieval, and instantiation capabilities.

## Changes

- **`src/alpacalyzer/strategies/registry.py`**: New `StrategyRegistry` class with:
  - `register()`: Register strategy classes with optional default configs
  - `get()`: Retrieve singleton or custom-configured strategy instances
  - `list_strategies()`: List all registered strategy names
  - `get_default_config()`: Get default config for a strategy
  - Instance caching for singleton access (no custom config)
  - Auto-registration placeholder for built-in strategies

- **`tests/test_strategy_registry.py`**: Comprehensive test suite (13 tests):
  - Strategy registration with and without default configs
  - Singleton instance caching
  - Custom config handling
  - Error handling for unknown strategies
  - Strategy listing
  - Registration override behavior

- **`src/alpacalyzer/strategies/__init__.py`**: Export `StrategyRegistry`
- **`src/alpacalyzer/cli.py`**: Add `--strategy` CLI argument

## Verification

- ✅ All 13 new tests pass
- ✅ All 83 existing tests pass
- ✅ Linting clean (ruff)
- ✅ Formatting applied
- ✅ Type checking passes on registry.py

## Note

The pre-commit `ty` hook has pre-existing type warnings in other files (e.g., `eod_performance.py`, `technical_analysis.py`) that are unrelated to this PR. The new code is type-safe.

Fixes #7