### PR TITLE
[Phase 2] Implement PositionTracker (#11)

### DIFF
--- a/src/alpacalyzer/execution/__init__.py
+++ b/src/alpacalyzer/execution/__init__.py
@@ -1,6 +1,14 @@
 """Execution module for order management and trade execution."""
 
 from alpacalyzer.execution.order_manager import OrderManager, OrderParams
+from alpacalyzer.execution.position_tracker import PositionTracker, TrackedPosition
 from alpacalyzer.execution.signal_queue import PendingSignal, SignalQueue
 
-__all__ = ["OrderManager", "OrderParams", "PendingSignal", "SignalQueue"]
+__all__ = [
+    "OrderManager",
+    "OrderParams",
+    "PendingSignal",
+    "SignalQueue",
+    "PositionTracker",
+    "TrackedPosition",
+]

--- a/src/alpacalyzer/execution/position_tracker.py
+++ b/src/alpacalyzer/execution/position_tracker.py
@@ -1,0 +1,325 @@
+"""PositionTracker for enriched local position state with broker synchronization."""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from alpaca.trading.models import Position
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class TrackedPosition:
+    """
+    Enriched position data beyond broker-provided information.
+
+    Tracks positions with strategy association, entry timestamps,
+    stop loss/target tracking, and exit attempt history.
+    """
+
+    # Core position data
+    ticker: str
+    side: str
+    quantity: int
+    avg_entry_price: float
+    current_price: float
+
+    # Computed values
+    market_value: float
+    unrealized_pnl: float
+    unrealized_pnl_pct: float
+
+    # Enriched metadata
+    strategy_name: str
+    opened_at: datetime
+    entry_order_id: str | None = None
+    stop_loss: float | None = None
+    target: float | None = None
+
+    # State tracking
+    exit_attempts: int = 0
+    last_exit_attempt: datetime | None = None
+    notes: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_alpaca_position(
+        cls,
+        position: Position,
+        strategy_name: str = "unknown",
+        opened_at: datetime | None = None,
+        stop_loss: float | None = None,
+        target: float | None = None,
+    ) -> "TrackedPosition":
+        """
+        Create a TrackedPosition from an Alpaca Position.
+
+        Args:
+            position: Alpaca Position object
+            strategy_name: Strategy that opened this position
+            opened_at: When position was opened (defaults to now)
+            stop_loss: Stop loss price
+            target: Target price
+
+        Returns:
+            TrackedPosition with enriched metadata
+        """
+        qty = int(float(position.qty))
+        entry = float(position.avg_entry_price)
+        current = float(position.current_price) if position.current_price else entry
+        mkt_value = float(position.market_value) if position.market_value else qty * current
+        pnl = float(position.unrealized_pl) if position.unrealized_pl else 0.0
+        pnl_pct = float(position.unrealized_plpc) if position.unrealized_plpc else 0.0
+
+        return cls(
+            ticker=position.symbol,
+            side=position.side,
+            quantity=qty,
+            avg_entry_price=entry,
+            current_price=current,
+            market_value=mkt_value,
+            unrealized_pnl=pnl,
+            unrealized_pnl_pct=pnl_pct,
+            strategy_name=strategy_name,
+            opened_at=opened_at or datetime.now(UTC),
+            stop_loss=stop_loss,
+            target=target,
+        )
+
+    def update_price(self, new_price: float) -> None:
+        """
+        Update current price and recalculate P&L.
+
+        Args:
+            new_price: New current price
+        """
+        self.current_price = new_price
+        self.market_value = self.quantity * new_price
+
+        if self.side == "long":
+            self.unrealized_pnl = (new_price - self.avg_entry_price) * self.quantity
+        else:
+            self.unrealized_pnl = (self.avg_entry_price - new_price) * self.quantity
+
+        if self.avg_entry_price > 0:
+            self.unrealized_pnl_pct = self.unrealized_pnl / (self.avg_entry_price * self.quantity)
+        else:
+            self.unrealized_pnl_pct = 0.0
+
+    def record_exit_attempt(self, reason: str) -> None:
+        """
+        Record an exit attempt.
+
+        Args:
+            reason: Reason for exit attempt
+        """
+        self.exit_attempts += 1
+        self.last_exit_attempt = datetime.now(UTC)
+        self.notes.append(f"Exit attempt {self.exit_attempts}: {reason}")
+
+
+class PositionTracker:
+    """
+    Manages local position state with broker synchronization.
+
+    Features:
+    - Rich position metadata (strategy, entry time, stop/target)
+    - Broker synchronization (detects adds/updates/removes)
+    - Position history for analytics
+    - Query interface for filtering
+    """
+
+    def __init__(self):
+        """Initialize PositionTracker."""
+        self._positions: dict[str, TrackedPosition] = {}
+        self._closed_positions: list[TrackedPosition] = []
+        self._last_sync: datetime | None = None
+
+    def sync_from_broker(self) -> list[str]:
+        """
+        Sync positions from Alpaca broker.
+
+        Updates existing positions, adds new ones, and moves closed
+        positions to history.
+
+        Returns:
+            List of tickers that changed (added or removed)
+        """
+        from alpacalyzer.trading.alpaca_client import get_positions
+
+        broker_positions = get_positions()
+        broker_tickers = {p.symbol for p in broker_positions}
+        local_tickers = set(self._positions.keys())
+
+        changes = []
+
+        # Update existing / add new positions
+        for pos in broker_positions:
+            ticker = pos.symbol
+
+            if ticker in self._positions:
+                # Update existing position
+                tracked = self._positions[ticker]
+                new_price = float(pos.current_price) if pos.current_price else tracked.current_price
+                tracked.update_price(new_price)
+            else:
+                # New position (opened outside our system or missed)
+                self._positions[ticker] = TrackedPosition.from_alpaca_position(pos)
+                changes.append(ticker)
+
+        # Handle closed positions
+        for ticker in local_tickers - broker_tickers:
+            closed = self._positions.pop(ticker)
+            self._closed_positions.append(closed)
+            changes.append(ticker)
+
+        self._last_sync = datetime.now(UTC)
+        return changes
+
+    def add_position(
+        self,
+        ticker: str,
+        side: str,
+        quantity: int,
+        entry_price: float,
+        strategy_name: str,
+        order_id: str | None = None,
+        stop_loss: float | None = None,
+        target: float | None = None,
+    ) -> TrackedPosition:
+        """
+        Add a new position (called after order fill).
+
+        Args:
+            ticker: Stock ticker symbol
+            side: Position side ("long" or "short")
+            quantity: Number of shares
+            entry_price: Average entry price
+            strategy_name: Strategy that opened this position
+            order_id: Entry order ID
+            stop_loss: Stop loss price
+            target: Target price
+
+        Returns:
+            Created TrackedPosition
+        """
+        position = TrackedPosition(
+            ticker=ticker,
+            side=side,
+            quantity=quantity,
+            avg_entry_price=entry_price,
+            current_price=entry_price,
+            market_value=quantity * entry_price,
+            unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0,
+            strategy_name=strategy_name,
+            opened_at=datetime.now(UTC),
+            entry_order_id=order_id,
+            stop_loss=stop_loss,
+            target=target,
+        )
+        self._positions[ticker] = position
+        return position
+
+    def remove_position(self, ticker: str) -> TrackedPosition | None:
+        """
+        Remove a position (called after exit).
+
+        Moves position to history.
+
+        Args:
+            ticker: Stock ticker symbol
+
+        Returns:
+            Removed TrackedPosition or None if not found
+        """
+        if ticker in self._positions:
+            position = self._positions.pop(ticker)
+            self._closed_positions.append(position)
+            return position
+        return None
+
+    def get(self, ticker: str) -> TrackedPosition | None:
+        """
+        Get a position by ticker.
+
+        Args:
+            ticker: Stock ticker symbol
+
+        Returns:
+            TrackedPosition or None if not found
+        """
+        return self._positions.get(ticker)
+
+    def get_all(self) -> list[TrackedPosition]:
+        """
+        Get all current positions.
+
+        Returns:
+            List of all open positions
+        """
+        return list(self._positions.values())
+
+    def get_by_strategy(self, strategy_name: str) -> list[TrackedPosition]:
+        """
+        Get positions opened by a specific strategy.
+
+        Args:
+            strategy_name: Strategy name to filter by
+
+        Returns:
+            List of positions for the strategy
+        """
+        return [p for p in self._positions.values() if p.strategy_name == strategy_name]
+
+    def has_position(self, ticker: str) -> bool:
+        """
+        Check if we have a position in a ticker.
+
+        Args:
+            ticker: Stock ticker symbol
+
+        Returns:
+            True if position exists
+        """
+        return ticker in self._positions
+
+    def count(self) -> int:
+        """
+        Get number of open positions.
+
+        Returns:
+            Number of open positions
+        """
+        return len(self._positions)
+
+    def total_value(self) -> float:
+        """
+        Get total market value of all positions.
+
+        Returns:
+            Total market value
+        """
+        return sum(p.market_value for p in self._positions.values())
+
+    def total_pnl(self) -> float:
+        """
+        Get total unrealized P&L.
+
+        Returns:
+            Total unrealized profit/loss
+        """
+        return sum(p.unrealized_pnl for p in self._positions.values())
+
+    def get_closed_positions(self, limit: int = 100) -> list[TrackedPosition]:
+        """
+        Get recently closed positions.
+
+        Args:
+            limit: Maximum number of positions to return
+
+        Returns:
+            List of recently closed positions
+        """
+        return self._closed_positions[-limit:]

--- a/tests/test_execution/test_position_tracker.py
+++ b/tests/test_execution/test_position_tracker.py
@@ -1,0 +1,581 @@
+"""Tests for PositionTracker module."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from alpaca.trading.models import Position
+
+
+class TestTrackedPosition:
+    """Tests for TrackedPosition dataclass."""
+
+    def test_tracked_position_creation(self):
+        """Test creating a TrackedPosition."""
+        from alpacalyzer.execution.position_tracker import TrackedPosition
+
+        position = TrackedPosition(
+            ticker="AAPL",
+            side="long",
+            quantity=100,
+            avg_entry_price=150.0,
+            current_price=155.0,
+            market_value=15500.0,
+            unrealized_pnl=500.0,
+            unrealized_pnl_pct=0.0333,
+            strategy_name="momentum",
+            opened_at=datetime.now(UTC),
+            entry_order_id="order_123",
+            stop_loss=145.0,
+            target=165.0,
+        )
+
+        assert position.ticker == "AAPL"
+        assert position.side == "long"
+        assert position.quantity == 100
+        assert position.avg_entry_price == 150.0
+        assert position.current_price == 155.0
+        assert position.market_value == 15500.0
+        assert position.unrealized_pnl == 500.0
+        assert position.strategy_name == "momentum"
+        assert position.stop_loss == 145.0
+        assert position.target == 165.0
+
+    def test_tracked_position_defaults(self):
+        """Test TrackedPosition default values."""
+        from alpacalyzer.execution.position_tracker import TrackedPosition
+
+        position = TrackedPosition(
+            ticker="AAPL",
+            side="long",
+            quantity=100,
+            avg_entry_price=150.0,
+            current_price=150.0,
+            market_value=15000.0,
+            unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0,
+            strategy_name="momentum",
+            opened_at=datetime.now(UTC),
+        )
+
+        assert position.entry_order_id is None
+        assert position.stop_loss is None
+        assert position.target is None
+        assert position.exit_attempts == 0
+        assert position.last_exit_attempt is None
+        assert position.notes == []
+
+    def test_from_alpaca_position_long(self):
+        """Test creating TrackedPosition from Alpaca Position (long)."""
+        from alpacalyzer.execution.position_tracker import TrackedPosition
+
+        mock_position = MagicMock(spec=Position)
+        mock_position.symbol = "AAPL"
+        mock_position.side = "long"
+        mock_position.qty = "100"
+        mock_position.avg_entry_price = "150.0"
+        mock_position.current_price = "155.0"
+        mock_position.market_value = "15500.0"
+        mock_position.unrealized_pl = "500.0"
+        mock_position.unrealized_plpc = "0.0333"
+
+        tracked = TrackedPosition.from_alpaca_position(
+            mock_position,
+            strategy_name="momentum",
+            opened_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+            stop_loss=145.0,
+            target=165.0,
+        )
+
+        assert tracked.ticker == "AAPL"
+        assert tracked.side == "long"
+        assert tracked.quantity == 100
+        assert tracked.avg_entry_price == 150.0
+        assert tracked.current_price == 155.0
+        assert tracked.market_value == 15500.0
+        assert tracked.unrealized_pnl == 500.0
+        assert tracked.unrealized_pnl_pct == 0.0333
+        assert tracked.strategy_name == "momentum"
+        assert tracked.opened_at == datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        assert tracked.stop_loss == 145.0
+        assert tracked.target == 165.0
+
+    def test_from_alpaca_position_short(self):
+        """Test creating TrackedPosition from Alpaca Position (short)."""
+        from alpacalyzer.execution.position_tracker import TrackedPosition
+
+        mock_position = MagicMock(spec=Position)
+        mock_position.symbol = "TSLA"
+        mock_position.side = "short"
+        mock_position.qty = "50"
+        mock_position.avg_entry_price = "200.0"
+        mock_position.current_price = "195.0"
+        mock_position.market_value = "9750.0"
+        mock_position.unrealized_pl = "250.0"
+        mock_position.unrealized_plpc = "0.025"
+
+        tracked = TrackedPosition.from_alpaca_position(
+            mock_position,
+            strategy_name="momentum",
+        )
+
+        assert tracked.ticker == "TSLA"
+        assert tracked.side == "short"
+        assert tracked.quantity == 50
+        assert tracked.avg_entry_price == 200.0
+        assert tracked.current_price == 195.0
+
+    def test_from_alpaca_position_missing_optional_fields(self):
+        """Test from_alpaca_position handles missing optional fields."""
+        from alpacalyzer.execution.position_tracker import TrackedPosition
+
+        mock_position = MagicMock(spec=Position)
+        mock_position.symbol = "AAPL"
+        mock_position.side = "long"
+        mock_position.qty = "100"
+        mock_position.avg_entry_price = "150.0"
+        mock_position.current_price = None
+        mock_position.market_value = None
+        mock_position.unrealized_pl = None
+        mock_position.unrealized_plpc = None
+
+        tracked = TrackedPosition.from_alpaca_position(mock_position)
+
+        assert tracked.current_price == 150.0
+        assert tracked.market_value == 15000.0
+        assert tracked.unrealized_pnl == 0.0
+        assert tracked.unrealized_pnl_pct == 0.0
+
+    def test_update_price_long(self):
+        """Test update_price for long position."""
+        from alpacalyzer.execution.position_tracker import TrackedPosition
+
+        position = TrackedPosition(
+            ticker="AAPL",
+            side="long",
+            quantity=100,
+            avg_entry_price=150.0,
+            current_price=150.0,
+            market_value=15000.0,
+            unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0,
+            strategy_name="momentum",
+            opened_at=datetime.now(UTC),
+        )
+
+        position.update_price(160.0)
+
+        assert position.current_price == 160.0
+        assert position.market_value == 16000.0
+        assert position.unrealized_pnl == 1000.0
+        assert abs(position.unrealized_pnl_pct - 0.0667) < 0.0001
+
+    def test_update_price_short(self):
+        """Test update_price for short position."""
+        from alpacalyzer.execution.position_tracker import TrackedPosition
+
+        position = TrackedPosition(
+            ticker="TSLA",
+            side="short",
+            quantity=50,
+            avg_entry_price=200.0,
+            current_price=200.0,
+            market_value=10000.0,
+            unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0,
+            strategy_name="momentum",
+            opened_at=datetime.now(UTC),
+        )
+
+        position.update_price(190.0)
+
+        assert position.current_price == 190.0
+        assert position.market_value == 9500.0
+        assert position.unrealized_pnl == 500.0
+
+    def test_update_price_zero_entry(self):
+        """Test update_price handles zero entry price."""
+        from alpacalyzer.execution.position_tracker import TrackedPosition
+
+        position = TrackedPosition(
+            ticker="AAPL",
+            side="long",
+            quantity=100,
+            avg_entry_price=0.0,
+            current_price=0.0,
+            market_value=0.0,
+            unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0,
+            strategy_name="momentum",
+            opened_at=datetime.now(UTC),
+        )
+
+        position.update_price(150.0)
+
+        assert position.current_price == 150.0
+        assert position.unrealized_pnl_pct == 0.0
+
+    def test_record_exit_attempt(self):
+        """Test record_exit_attempt increments counter and adds note."""
+        from alpacalyzer.execution.position_tracker import TrackedPosition
+
+        position = TrackedPosition(
+            ticker="AAPL",
+            side="long",
+            quantity=100,
+            avg_entry_price=150.0,
+            current_price=150.0,
+            market_value=15000.0,
+            unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0,
+            strategy_name="momentum",
+            opened_at=datetime.now(UTC),
+        )
+
+        position.record_exit_attempt("Stop loss hit")
+
+        assert position.exit_attempts == 1
+        assert position.last_exit_attempt is not None
+        assert len(position.notes) == 1
+        assert "Exit attempt 1: Stop loss hit" in position.notes[0]
+
+        position.record_exit_attempt("Target reached")
+
+        assert position.exit_attempts == 2
+        assert len(position.notes) == 2
+        assert "Exit attempt 2: Target reached" in position.notes[1]
+
+
+class TestPositionTracker:
+    """Tests for PositionTracker class."""
+
+    def test_position_tracker_creation(self):
+        """Test creating a PositionTracker."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+
+        assert tracker.count() == 0
+        assert tracker.total_value() == 0.0
+        assert tracker.total_pnl() == 0.0
+        assert tracker.get_all() == []
+        assert tracker._last_sync is None
+
+    def test_add_position(self):
+        """Test adding a new position."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        opened_at = datetime.now(UTC)
+
+        position = tracker.add_position(
+            ticker="AAPL",
+            side="long",
+            quantity=100,
+            entry_price=150.0,
+            strategy_name="momentum",
+            order_id="order_123",
+            stop_loss=145.0,
+            target=165.0,
+        )
+
+        assert position.ticker == "AAPL"
+        assert position.side == "long"
+        assert position.quantity == 100
+        assert position.avg_entry_price == 150.0
+        assert position.strategy_name == "momentum"
+        assert position.entry_order_id == "order_123"
+        assert position.stop_loss == 145.0
+        assert position.target == 165.0
+        assert position.opened_at >= opened_at
+
+        assert tracker.count() == 1
+        assert tracker.has_position("AAPL") is True
+
+    def test_add_position_minimal(self):
+        """Test adding position with minimal parameters."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+
+        position = tracker.add_position(
+            ticker="AAPL",
+            side="long",
+            quantity=100,
+            entry_price=150.0,
+            strategy_name="momentum",
+        )
+
+        assert position.entry_order_id is None
+        assert position.stop_loss is None
+        assert position.target is None
+
+    def test_remove_position(self):
+        """Test removing a position."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+
+        removed = tracker.remove_position("AAPL")
+
+        assert removed is not None
+        assert removed.ticker == "AAPL"
+        assert tracker.count() == 0
+        assert tracker.has_position("AAPL") is False
+
+    def test_remove_nonexistent_position(self):
+        """Test removing a position that doesn't exist."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+
+        removed = tracker.remove_position("AAPL")
+
+        assert removed is None
+        assert tracker.count() == 0
+
+    def test_remove_position_moves_to_history(self):
+        """Test that removed positions are moved to history."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+        tracker.add_position(ticker="MSFT", side="long", quantity=50, entry_price=300.0, strategy_name="momentum")
+
+        tracker.remove_position("AAPL")
+
+        assert tracker.count() == 1
+        closed = tracker.get_closed_positions()
+        assert len(closed) == 1
+        assert closed[0].ticker == "AAPL"
+
+    def test_get_position(self):
+        """Test getting a position by ticker."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+
+        position = tracker.get("AAPL")
+
+        assert position is not None
+        assert position.ticker == "AAPL"
+
+    def test_get_nonexistent_position(self):
+        """Test getting a position that doesn't exist."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+
+        position = tracker.get("AAPL")
+
+        assert position is None
+
+    def test_get_all_positions(self):
+        """Test getting all positions."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+        tracker.add_position(ticker="MSFT", side="long", quantity=50, entry_price=300.0, strategy_name="swing")
+        tracker.add_position(ticker="TSLA", side="short", quantity=25, entry_price=200.0, strategy_name="momentum")
+
+        positions = tracker.get_all()
+
+        assert len(positions) == 3
+        tickers = {p.ticker for p in positions}
+        assert tickers == {"AAPL", "MSFT", "TSLA"}
+
+    def test_get_by_strategy(self):
+        """Test filtering positions by strategy."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+        tracker.add_position(ticker="MSFT", side="long", quantity=50, entry_price=300.0, strategy_name="swing")
+        tracker.add_position(ticker="TSLA", side="short", quantity=25, entry_price=200.0, strategy_name="momentum")
+
+        momentum_positions = tracker.get_by_strategy("momentum")
+
+        assert len(momentum_positions) == 2
+        tickers = {p.ticker for p in momentum_positions}
+        assert tickers == {"AAPL", "TSLA"}
+
+    def test_has_position(self):
+        """Test checking if a ticker has a position."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+
+        assert tracker.has_position("AAPL") is True
+        assert tracker.has_position("MSFT") is False
+
+    def test_count(self):
+        """Test counting open positions."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        assert tracker.count() == 0
+
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+        assert tracker.count() == 1
+
+        tracker.add_position(ticker="MSFT", side="long", quantity=50, entry_price=300.0, strategy_name="swing")
+        assert tracker.count() == 2
+
+    def test_total_value(self):
+        """Test calculating total market value."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+        tracker.add_position(ticker="MSFT", side="long", quantity=50, entry_price=300.0, strategy_name="swing")
+
+        total = tracker.total_value()
+
+        assert total == 15000.0 + 15000.0
+
+    def test_total_pnl(self):
+        """Test calculating total unrealized P&L."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        pos1 = tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+        pos2 = tracker.add_position(ticker="MSFT", side="long", quantity=50, entry_price=300.0, strategy_name="swing")
+
+        pos1.update_price(160.0)
+        pos2.update_price(290.0)
+
+        total = tracker.total_pnl()
+
+        assert total == 1000.0 + (-500.0)
+
+    def test_get_closed_positions(self):
+        """Test getting closed positions history."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+        tracker.add_position(ticker="MSFT", side="long", quantity=50, entry_price=300.0, strategy_name="swing")
+        tracker.add_position(ticker="TSLA", side="short", quantity=25, entry_price=200.0, strategy_name="hedge")
+
+        tracker.remove_position("AAPL")
+        tracker.remove_position("TSLA")
+
+        closed = tracker.get_closed_positions()
+
+        assert len(closed) == 2
+        tickers = [p.ticker for p in closed]
+        assert tickers == ["AAPL", "TSLA"]
+
+    def test_get_closed_positions_with_limit(self):
+        """Test get_closed_positions with limit parameter."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        for i in range(5):
+            tracker.add_position(ticker=f"STK{i}", side="long", quantity=100, entry_price=100.0, strategy_name="test")
+            tracker.remove_position(f"STK{i}")
+
+        closed = tracker.get_closed_positions(limit=3)
+
+        assert len(closed) == 3
+
+    def test_sync_from_broker_new_positions(self):
+        """Test sync_from_broker adds new positions."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        mock_position1 = MagicMock(spec=Position)
+        mock_position1.symbol = "AAPL"
+        mock_position1.side = "long"
+        mock_position1.qty = "100"
+        mock_position1.avg_entry_price = "150.0"
+        mock_position1.current_price = "155.0"
+        mock_position1.market_value = "15500.0"
+        mock_position1.unrealized_pl = "500.0"
+        mock_position1.unrealized_plpc = "0.0333"
+
+        tracker = PositionTracker()
+
+        with patch("alpacalyzer.trading.alpaca_client.get_positions", return_value=[mock_position1]):
+            changes = tracker.sync_from_broker()
+
+        assert len(changes) == 1
+        assert "AAPL" in changes
+        assert tracker.count() == 1
+        assert tracker.has_position("AAPL") is True
+        assert tracker._last_sync is not None
+
+    def test_sync_from_broker_update_existing(self):
+        """Test sync_from_broker updates existing positions."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+
+        mock_position = MagicMock(spec=Position)
+        mock_position.symbol = "AAPL"
+        mock_position.side = "long"
+        mock_position.qty = "100"
+        mock_position.avg_entry_price = "150.0"
+        mock_position.current_price = "160.0"
+        mock_position.market_value = "16000.0"
+        mock_position.unrealized_pl = "1000.0"
+        mock_position.unrealized_plpc = "0.0667"
+
+        with patch("alpacalyzer.trading.alpaca_client.get_positions", return_value=[mock_position]):
+            changes = tracker.sync_from_broker()
+
+        assert len(changes) == 0
+        assert tracker.count() == 1
+        position = tracker.get("AAPL")
+        assert position is not None
+        assert position.current_price == 160.0
+        assert position.market_value == 16000.0
+        assert position.unrealized_pnl == 1000.0
+
+    def test_sync_from_broker_remove_closed(self):
+        """Test sync_from_broker removes closed positions."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+        tracker.add_position(ticker="MSFT", side="long", quantity=50, entry_price=300.0, strategy_name="swing")
+
+        with patch("alpacalyzer.trading.alpaca_client.get_positions", return_value=[]):
+            changes = tracker.sync_from_broker()
+
+        assert len(changes) == 2
+        assert "AAPL" in changes
+        assert "MSFT" in changes
+        assert tracker.count() == 0
+        closed = tracker.get_closed_positions()
+        assert len(closed) == 2
+
+    def test_sync_from_broker_mixed_changes(self):
+        """Test sync_from_broker with mixed adds/updates/removes."""
+        from alpacalyzer.execution.position_tracker import PositionTracker
+
+        tracker = PositionTracker()
+        tracker.add_position(ticker="AAPL", side="long", quantity=100, entry_price=150.0, strategy_name="momentum")
+        tracker.add_position(ticker="MSFT", side="long", quantity=50, entry_price=300.0, strategy_name="swing")
+
+        mock_position = MagicMock(spec=Position)
+        mock_position.symbol = "AAPL"
+        mock_position.side = "long"
+        mock_position.qty = "100"
+        mock_position.avg_entry_price = "150.0"
+        mock_position.current_price = "160.0"
+        mock_position.market_value = "16000.0"
+        mock_position.unrealized_pl = "1000.0"
+        mock_position.unrealized_plpc = "0.0667"
+
+        with patch("alpacalyzer.trading.alpaca_client.get_positions", return_value=[mock_position]):
+            changes = tracker.sync_from_broker()
+
+        assert len(changes) == 1
+        assert "MSFT" in changes
+        assert tracker.count() == 1
+        assert tracker.has_position("AAPL") is True
+        assert tracker.has_position("MSFT") is False


### PR DESCRIPTION
## Summary
Implements `PositionTracker` class for enriched local position state with broker synchronization.

## Changes

### TrackedPosition Dataclass
- Core position data: ticker, side, quantity, avg_entry_price, current_price
- Computed values: market_value, unrealized_pnl, unrealized_pnl_pct
- Enriched metadata: strategy_name, opened_at, entry_order_id, stop_loss, target
- State tracking: exit_attempts, last_exit_attempt, notes
- `from_alpaca_position()` - Create from Alpaca Position
- `update_price()` - Update price and recalculate P&L
- `record_exit_attempt()` - Track exit attempts

### PositionTracker Class
- `_positions`: Current positions dict keyed by ticker
- `_closed_positions`: Historical positions list
- `_last_sync`: Last sync time tracking
- `sync_from_broker()`: Sync from Alpaca, return changed tickers
- `add_position()`: Add new position after fill
- `remove_position()`: Remove position after exit, move to history
- Query methods: `get()`, `get_all()`, `get_by_strategy()`, `has_position()`, `count()`, `total_value()`, `total_pnl()`
- `get_closed_positions()`: Get history with limit

## Tests
- 29 comprehensive tests with 100% coverage
- Tests for TrackedPosition creation, from_alpaca_position, update_price, record_exit_attempt
- Tests for PositionTracker sync logic (add, update, remove)
- Tests for query methods and position history

## Acceptance Criteria
- ✅ TrackedPosition with all required fields
- ✅ PositionTracker with sync and query methods
- ✅ Broker sync correctly handles adds/removes
- ✅ Position history preserved
- ✅ Strategy association tracked
- ✅ Unit tests with 90%+ coverage (actually 100%)

Closes #11