### PR TITLE
feat(data): remove dead Position and Portfolio classes for #56

### DIFF
--- a/src/alpacalyzer/data/models.py
+++ b/src/alpacalyzer/data/models.py
@@ -132,17 +132,6 @@ class CompanyNewsResponse(BaseModel):
     news: list[CompanyNews]
 
 
-class Position(BaseModel):
-    cash: float = 0.0
-    shares: int = 0
-    ticker: str
-
-
-class Portfolio(BaseModel):
-    positions: dict[str, Position]  # ticker -> Position mapping
-    total_cash: float = 0.0
-
-
 class AnalystSignal(BaseModel):
     signal: str | None = None
     confidence: float | None = None
@@ -152,14 +141,6 @@ class AnalystSignal(BaseModel):
 class TickerAnalysis(BaseModel):
     ticker: str
     analyst_signals: dict[str, AnalystSignal]  # agent_name -> signal mapping
-
-
-class AgentStateData(BaseModel):
-    tickers: list[str]
-    portfolio: Portfolio
-    start_date: str
-    end_date: str
-    ticker_analyses: dict[str, TickerAnalysis]  # ticker -> analysis mapping
 
 
 class AgentStateMetadata(BaseModel):

--- a/tests/strategies/test_base.py
+++ b/tests/strategies/test_base.py
@@ -2,9 +2,10 @@
 
 import pandas as pd
 import pytest
+from alpaca.trading.models import Position
 
 from alpacalyzer.analysis.technical_analysis import TradingSignals
-from alpacalyzer.data.models import Position, TradingStrategy
+from alpacalyzer.data.models import TradingStrategy
 from alpacalyzer.strategies.base import BaseStrategy, EntryDecision, ExitDecision, MarketContext
 
 

--- a/tests/strategies/test_strategy_protocol.py
+++ b/tests/strategies/test_strategy_protocol.py
@@ -1,9 +1,10 @@
 """Tests for Strategy protocol compliance."""
 
 import pytest
+from alpaca.trading.models import Position
 
 from alpacalyzer.analysis.technical_analysis import TradingSignals
-from alpacalyzer.data.models import Position, TradingStrategy
+from alpacalyzer.data.models import TradingStrategy
 from alpacalyzer.strategies.base import BaseStrategy, EntryDecision, ExitDecision, MarketContext, Strategy
 
 


### PR DESCRIPTION
## Summary

Removed dead `Position` and `Portfolio` classes from `src/alpacalyzer/data/models.py` and updated test imports to use `alpaca.trading.models.Position`.

## Changes

- Removed unused `Position` class (local model with `cash`, `shares`, `ticker`)
- Removed unused `Portfolio` class (depended on `Position`)
- Removed unused `AgentStateData` class (depended on `Portfolio`)
- Updated `tests/strategies/test_base.py` to import `Position` from `alpaca.trading.models`
- Updated `tests/strategies/test_strategy_protocol.py` to import `Position` from `alpaca.trading.models`

## Impact

- Low risk - these classes were never instantiated in production code
- Fixes type compatibility issues between tests and the actual `alpaca.trading.models.Position` type used by `BaseStrategy`

## Testing

All 430 tests pass with no errors.