### PR TITLE
feat(scanners): implement RedditScannerAdapter and SocialScannerAdapter for #61

### DIFF
--- a/src/alpacalyzer/pipeline/registry.py
+++ b/src/alpacalyzer/pipeline/registry.py
@@ -98,4 +98,19 @@ def get_scanner_registry() -> ScannerRegistry:
     Returns:
         The global ScannerRegistry instance.
     """
-    return ScannerRegistry.get_instance()
+    registry = ScannerRegistry.get_instance()
+    if not registry._scanners:
+        _register_scanner_adapters(registry)
+    return registry
+
+
+def _register_scanner_adapters(registry: ScannerRegistry | None = None) -> None:
+    """Register scanner adapters (lazy registration to avoid circular imports)."""
+    from alpacalyzer.scanners.adapters import RedditScannerAdapter, SocialScannerAdapter
+
+    if registry is None:
+        registry = ScannerRegistry.get_instance()
+    if "reddit" not in registry._scanners:
+        registry.register(RedditScannerAdapter())
+    if "social" not in registry._scanners:
+        registry.register(SocialScannerAdapter())

--- a/src/alpacalyzer/scanners/__init__.py
+++ b/src/alpacalyzer/scanners/__init__.py
@@ -1,0 +1,6 @@
+from alpacalyzer.scanners.adapters import RedditScannerAdapter, SocialScannerAdapter
+
+__all__ = [
+    "RedditScannerAdapter",
+    "SocialScannerAdapter",
+]

--- a/src/alpacalyzer/scanners/adapters.py
+++ b/src/alpacalyzer/scanners/adapters.py
@@ -1,0 +1,127 @@
+"""Scanner adapters implementing BaseScanner protocol."""
+
+from datetime import UTC, datetime
+
+import pandas as pd
+from alpaca.trading.enums import OrderSide
+
+from alpacalyzer.analysis.technical_analysis import TechnicalAnalyzer
+from alpacalyzer.data.models import TopTicker
+from alpacalyzer.events import ScanCompleteEvent, emit_event
+from alpacalyzer.pipeline.scanner_protocol import BaseScanner
+from alpacalyzer.scanners.finviz_scanner import FinvizScanner
+from alpacalyzer.scanners.social_scanner import SocialScanner
+from alpacalyzer.trading.opportunity_finder import get_reddit_insights, get_top_candidates
+from alpacalyzer.trading.yfinance_client import YFinanceClient
+from alpacalyzer.utils.logger import get_logger
+
+logger = get_logger()
+
+
+class RedditScannerAdapter(BaseScanner):
+    """Adapter for Reddit/insight scanning."""
+
+    def __init__(self):
+        super().__init__(name="reddit", enabled=True)
+        self._finviz = FinvizScanner()
+
+    def _execute_scan(self) -> list[TopTicker]:
+        insights = get_reddit_insights()
+        if not insights or not insights.top_tickers:
+            return []
+
+        tickers = [x.ticker for x in insights.top_tickers]
+        ta_df = self._finviz.fetch_stock_data(tuple(tickers))
+        if ta_df.empty:
+            return []
+
+        candidates = get_top_candidates(insights.top_tickers, ta_df)
+        if not candidates or not candidates.top_tickers:
+            return []
+
+        emit_event(
+            ScanCompleteEvent(
+                timestamp=datetime.now(UTC),
+                source="reddit",
+                tickers_found=[t.ticker for t in candidates.top_tickers],
+                duration_seconds=0.0,
+            )
+        )
+
+        return candidates.top_tickers
+
+
+class SocialScannerAdapter(BaseScanner):
+    """Adapter for social/technical scanning with TA filtering."""
+
+    def __init__(self):
+        super().__init__(name="social", enabled=True)
+        self._scanner = SocialScanner()
+        self._ta = TechnicalAnalyzer()
+        self._yfinance = YFinanceClient()
+
+    def _execute_scan(self) -> list[TopTicker]:
+        df = self._scanner.get_trending_stocks(10)
+        if df.empty:
+            emit_event(
+                ScanCompleteEvent(
+                    timestamp=datetime.now(UTC),
+                    source="social",
+                    tickers_found=[],
+                    duration_seconds=0.0,
+                )
+            )
+            return []
+
+        vix = self._yfinance.get_vix()
+        opportunities = []
+
+        for _, stock in df.iterrows():
+            signals = stock.get("trading_signals")
+            if not isinstance(signals, dict):
+                continue
+
+            if not self._passes_filters(signals, stock, vix):
+                continue
+
+            signal = "bullish" if signals["score"] > 0.8 else "neutral"
+            opportunities.append(
+                TopTicker(
+                    ticker=stock["ticker"],
+                    confidence=75,
+                    signal=signal,
+                    reasoning=f"Technical Score: {signals['score']:.2f}",
+                )
+            )
+
+        emit_event(
+            ScanCompleteEvent(
+                timestamp=datetime.now(UTC),
+                source="social",
+                tickers_found=[t.ticker for t in opportunities],
+                duration_seconds=0.0,
+            )
+        )
+
+        return opportunities
+
+    def _passes_filters(self, signals: dict, stock: pd.Series, vix: float) -> bool:
+        momentum = signals["momentum"]
+        score = signals["score"]
+        signal_list = signals["signals"]
+
+        atr_pct = signals["atr"] / signals["price"]
+        threshold = self._ta.calculate_ta_threshold(vix, signals["rvol"], atr_pct)
+
+        if score < threshold:
+            return False
+        if momentum < 0 and stock.get("sentiment_rank", 0) > 20:
+            return False
+        if momentum < -3:
+            return False
+        if 15 < vix < 30 and score < 0.8 and not any("Breakout" in s for s in signal_list):
+            return False
+        if self._ta.weak_technicals(signal_list, OrderSide.BUY):
+            return False
+
+        return True

--- a/tests/test_scanners/test_adapters.py
+++ b/tests/test_scanners/test_adapters.py
@@ -1,0 +1,323 @@
+"""Tests for scanner adapters."""
+
+from unittest.mock import patch
+
+import pandas as pd
+
+from alpacalyzer.data.models import TopTicker, TopTickersResponse
+from alpacalyzer.pipeline.registry import ScannerRegistry, _register_scanner_adapters
+from alpacalyzer.scanners.adapters import RedditScannerAdapter, SocialScannerAdapter
+
+
+class TestRedditScannerAdapter:
+    def setup_method(self):
+        ScannerRegistry.reset()
+        _register_scanner_adapters()
+
+    def test_reddit_scanner_adapter_name(self):
+        adapter = RedditScannerAdapter()
+        assert adapter.name == "reddit"
+        assert adapter.enabled is True
+
+    def test_reddit_scanner_returns_empty_when_no_insights(self):
+        with patch("alpacalyzer.scanners.adapters.get_reddit_insights", return_value=None):
+            adapter = RedditScannerAdapter()
+            result = adapter.scan()
+            assert result.success is True
+            assert result.count == 0
+            assert result.symbols() == []
+
+    def test_reddit_scanner_returns_empty_when_no_top_tickers(self):
+        with patch("alpacalyzer.scanners.adapters.get_reddit_insights", return_value=TopTickersResponse(top_tickers=[])):
+            adapter = RedditScannerAdapter()
+            result = adapter.scan()
+            assert result.success is True
+            assert result.count == 0
+
+    def test_reddit_scanner_returns_tickers_when_data_available(self):
+        top_tickers = [
+            TopTicker(ticker="AAPL", signal="bullish", confidence=80, reasoning="Test"),
+            TopTicker(ticker="GOOGL", signal="neutral", confidence=60, reasoning="Test"),
+        ]
+        ta_df = pd.DataFrame({"ticker": ["AAPL", "GOOGL"], "close": [150.0, 2800.0]})
+
+        with (
+            patch("alpacalyzer.scanners.adapters.get_reddit_insights", return_value=TopTickersResponse(top_tickers=top_tickers)),
+            patch("alpacalyzer.scanners.adapters.FinvizScanner.fetch_stock_data", return_value=ta_df),
+            patch("alpacalyzer.scanners.adapters.get_top_candidates", return_value=TopTickersResponse(top_tickers=top_tickers)),
+        ):
+            adapter = RedditScannerAdapter()
+            result = adapter.scan()
+
+            assert result.success is True
+            assert result.count == 2
+            assert "AAPL" in result.symbols()
+            assert "GOOGL" in result.symbols()
+
+    def test_reddit_scanner_returns_empty_when_finviz_empty(self):
+        top_tickers = [
+            TopTicker(ticker="AAPL", signal="bullish", confidence=80, reasoning="Test"),
+        ]
+
+        with (
+            patch("alpacalyzer.scanners.adapters.get_reddit_insights", return_value=TopTickersResponse(top_tickers=top_tickers)),
+            patch("alpacalyzer.scanners.adapters.FinvizScanner.fetch_stock_data", return_value=pd.DataFrame()),
+        ):
+            adapter = RedditScannerAdapter()
+            result = adapter.scan()
+
+            assert result.success is True
+            assert result.count == 0
+
+
+class TestSocialScannerAdapter:
+    def setup_method(self):
+        ScannerRegistry.reset()
+        _register_scanner_adapters()
+
+    def test_social_scanner_adapter_name(self):
+        adapter = SocialScannerAdapter()
+        assert adapter.name == "social"
+        assert adapter.enabled is True
+
+    def test_social_scanner_returns_empty_when_no_trending_stocks(self):
+        with patch("alpacalyzer.scanners.adapters.SocialScanner.get_trending_stocks", return_value=pd.DataFrame()):
+            adapter = SocialScannerAdapter()
+            result = adapter.scan()
+            assert result.success is True
+            assert result.count == 0
+
+    def test_social_scanner_filters_by_ta_threshold(self):
+        df = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "trading_signals": [
+                    {
+                        "score": 0.3,
+                        "momentum": 5.0,
+                        "atr": 2.0,
+                        "price": 100.0,
+                        "rvol": 2.0,
+                        "signals": ["TA: Breakout"],
+                    }
+                ],
+                "sentiment_rank": 10,
+            }
+        )
+
+        with (
+            patch("alpacalyzer.scanners.adapters.SocialScanner.get_trending_stocks", return_value=df),
+            patch("alpacalyzer.scanners.adapters.YFinanceClient.get_vix", return_value=15.0),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.calculate_ta_threshold", return_value=0.5),
+        ):
+            adapter = SocialScannerAdapter()
+            result = adapter.scan()
+            assert result.count == 0
+
+    def test_social_scanner_passes_valid_tickers(self):
+        df = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "trading_signals": [
+                    {
+                        "score": 0.6,
+                        "momentum": 5.0,
+                        "atr": 2.0,
+                        "price": 100.0,
+                        "rvol": 2.0,
+                        "signals": ["TA: Breakout"],
+                    }
+                ],
+                "sentiment_rank": 10,
+            }
+        )
+
+        with (
+            patch("alpacalyzer.scanners.adapters.SocialScanner.get_trending_stocks", return_value=df),
+            patch("alpacalyzer.scanners.adapters.YFinanceClient.get_vix", return_value=15.0),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.calculate_ta_threshold", return_value=0.5),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.weak_technicals", return_value=None),
+        ):
+            adapter = SocialScannerAdapter()
+            result = adapter.scan()
+
+            assert result.success is True
+            assert result.count == 1
+            assert "AAPL" in result.symbols()
+
+    def test_social_scanner_returns_bullish_for_high_score(self):
+        df = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "trading_signals": [
+                    {
+                        "score": 0.9,
+                        "momentum": 5.0,
+                        "atr": 2.0,
+                        "price": 100.0,
+                        "rvol": 2.0,
+                        "signals": ["TA: Breakout"],
+                    }
+                ],
+                "sentiment_rank": 10,
+            }
+        )
+
+        with (
+            patch("alpacalyzer.scanners.adapters.SocialScanner.get_trending_stocks", return_value=df),
+            patch("alpacalyzer.scanners.adapters.YFinanceClient.get_vix", return_value=15.0),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.calculate_ta_threshold", return_value=0.5),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.weak_technicals", return_value=None),
+        ):
+            adapter = SocialScannerAdapter()
+            result = adapter.scan()
+
+            assert result.success is True
+            assert result.count == 1
+            assert result.tickers[0].signal == "bullish"
+
+    def test_social_scanner_returns_neutral_for_medium_score(self):
+        df = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "trading_signals": [
+                    {
+                        "score": 0.5,
+                        "momentum": 5.0,
+                        "atr": 2.0,
+                        "price": 100.0,
+                        "rvol": 2.0,
+                        "signals": ["TA: Breakout"],
+                    }
+                ],
+                "sentiment_rank": 10,
+            }
+        )
+
+        with (
+            patch("alpacalyzer.scanners.adapters.SocialScanner.get_trending_stocks", return_value=df),
+            patch("alpacalyzer.scanners.adapters.YFinanceClient.get_vix", return_value=15.0),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.calculate_ta_threshold", return_value=0.4),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.weak_technicals", return_value=None),
+        ):
+            adapter = SocialScannerAdapter()
+            result = adapter.scan()
+
+            assert result.success is True
+            assert result.count == 1
+            assert result.tickers[0].signal == "neutral"
+
+    def test_social_scanner_filters_negative_momentum_with_high_sentiment(self):
+        df = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "trading_signals": [
+                    {
+                        "score": 0.6,
+                        "momentum": -5.0,
+                        "atr": 2.0,
+                        "price": 100.0,
+                        "rvol": 2.0,
+                        "signals": ["TA: Breakout"],
+                    }
+                ],
+                "sentiment_rank": 25,
+            }
+        )
+
+        with (
+            patch("alpacalyzer.scanners.adapters.SocialScanner.get_trending_stocks", return_value=df),
+            patch("alpacalyzer.scanners.adapters.YFinanceClient.get_vix", return_value=15.0),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.calculate_ta_threshold", return_value=0.5),
+        ):
+            adapter = SocialScannerAdapter()
+            result = adapter.scan()
+
+            assert result.count == 0
+
+    def test_social_scanner_filters_weak_momentum(self):
+        df = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "trading_signals": [
+                    {
+                        "score": 0.6,
+                        "momentum": -5.0,
+                        "atr": 2.0,
+                        "price": 100.0,
+                        "rvol": 2.0,
+                        "signals": ["TA: Breakout"],
+                    }
+                ],
+                "sentiment_rank": 10,
+            }
+        )
+
+        with (
+            patch("alpacalyzer.scanners.adapters.SocialScanner.get_trending_stocks", return_value=df),
+            patch("alpacalyzer.scanners.adapters.YFinanceClient.get_vix", return_value=15.0),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.calculate_ta_threshold", return_value=0.5),
+        ):
+            adapter = SocialScannerAdapter()
+            result = adapter.scan()
+
+            assert result.count == 0
+
+    def test_social_scanner_filters_weak_technicals(self):
+        df = pd.DataFrame(
+            {
+                "ticker": ["AAPL"],
+                "trading_signals": [
+                    {
+                        "score": 0.6,
+                        "momentum": 5.0,
+                        "atr": 2.0,
+                        "price": 100.0,
+                        "rvol": 2.0,
+                        "signals": ["TA: Breakout"],
+                    }
+                ],
+                "sentiment_rank": 10,
+            }
+        )
+
+        with (
+            patch("alpacalyzer.scanners.adapters.SocialScanner.get_trending_stocks", return_value=df),
+            patch("alpacalyzer.scanners.adapters.YFinanceClient.get_vix", return_value=15.0),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.calculate_ta_threshold", return_value=0.5),
+            patch("alpacalyzer.scanners.adapters.TechnicalAnalyzer.weak_technicals", return_value="Unfavorable technicals"),
+        ):
+            adapter = SocialScannerAdapter()
+            result = adapter.scan()
+
+            assert result.count == 0
+
+
+class TestScannerRegistryAutoRegistration:
+    def setup_method(self):
+        ScannerRegistry.reset()
+        _register_scanner_adapters()
+
+    def test_scanner_registry_has_reddit_adapter(self):
+        from alpacalyzer.pipeline.registry import get_scanner_registry
+
+        registry = get_scanner_registry()
+        assert "reddit" in registry.list_scanners()
+
+    def test_scanner_registry_has_social_adapter(self):
+        from alpacalyzer.pipeline.registry import get_scanner_registry
+
+        registry = get_scanner_registry()
+        assert "social" in registry.list_scanners()
+
+    def test_scanner_registry_run_all_returns_results(self):
+        from alpacalyzer.pipeline.registry import get_scanner_registry
+
+        with patch("alpacalyzer.scanners.adapters.get_reddit_insights", return_value=None), patch("alpacalyzer.scanners.adapters.SocialScanner.get_trending_stocks", return_value=pd.DataFrame()):
+            registry = get_scanner_registry()
+            results = list(registry.run_all())
+
+            assert len(results) == 2
+            source_names = [r.source for r in results]
+            assert "reddit" in source_names
+            assert "social" in source_names


### PR DESCRIPTION
## Summary

Created scanner adapters that wrap existing scanners (`SocialScanner`, `FinvizScanner`, etc.) to implement the `BaseScanner` protocol for use with `ScannerRegistry` and `OpportunityAggregator`.

## Changes

- **New**: `src/alpacalyzer/scanners/adapters.py` - Contains `RedditScannerAdapter` and `SocialScannerAdapter`
- **Modified**: `src/alpacalyzer/scanners/__init__.py` - Exports the new adapters
- **Modified**: `src/alpacalyzer/pipeline/registry.py` - Added lazy auto-registration of adapters
- **New**: `tests/test_scanners/test_adapters.py` - 17 comprehensive tests

## Key Implementation Details

- `RedditScannerAdapter` wraps `get_reddit_insights()` + `FinvizScanner.fetch_stock_data()` + `get_top_candidates()`
- `SocialScannerAdapter` preserves TA filtering logic from `scan_for_technical_opportunities()`:
  - `calculate_ta_threshold()` based on VIX, RVOL, ATR
  - Momentum and sentiment rank validation
  - VIX-based filtering (15 < VIX < 30 requires breakout pattern)
  - `weak_technicals()` check
- Both adapters emit `ScanCompleteEvent` on scan completion
- Lazy registration in `get_scanner_registry()` avoids circular import issues

## Tests

All 17 tests pass:
- RedditScannerAdapter tests (5)
- SocialScannerAdapter tests (10)
- ScannerRegistry auto-registration tests (3)