### PR TITLE
feat(risk): Implement dynamic position sizing based on ATR

### DIFF
--- a/src/alpacalyzer/trading/risk_manager.py
+++ b/src/alpacalyzer/trading/risk_manager.py
@@ -19,7 +19,7 @@ Calculates position limits and buying power adjustments for trading decisions.
 Position Sizing Rules:
 - DYNAMIC SIZING (primary): Based on ATR and VIX
   * Base risk: 2% of portfolio equity
-  * Adjusted for VIX: Reduce risk when market is fearful (VIX > 20)
+  * VIX scaling: VIX=20 (no reduction), VIX=30 (33% reduction), VIX=40 (50% reduction)
   * Shares = Risk Amount / (2 * ATR)  // ATR determines stop loss distance
   * Capped at 5% max position size
 - FIXED SIZING (fallback): 5% of portfolio equity
@@ -105,7 +105,11 @@ def calculate_dynamic_position_size(
         return portfolio_equity * max_position_pct
 
     risk_per_share = 2 * atr
-    shares = int(risk_amount / risk_per_share)
+    if risk_amount < risk_per_share:
+        logger.warning(f"Risk amount ${risk_amount:.2f} less than risk per share ${risk_per_share:.2f} for {ticker}, using minimum 1 share")
+        shares = 1
+    else:
+        shares = int(risk_amount / risk_per_share)
 
     position_size = shares * price
 


### PR DESCRIPTION
## Summary

Implements dynamic position sizing based on ATR volatility instead of fixed 5% per position.

## Changes

- Added `get_stock_atr()` function to fetch ATR from TechnicalAnalyzer
- Added `calculate_dynamic_position_size()` function with:
  - Base risk: 2% of portfolio equity
  - VIX scaling: reduces risk when market is fearful (VIX > 20)
  - ATR-based sizing: shares = risk_amount / (2 * ATR)
  - Cap at 5% max position size
  - Fallback to fixed 5% when ATR unavailable

## Technical Details

Position sizing formula:
```
Risk Amount = Equity * 2%
VIX Adjustment = Risk / (1 + VIX_Factor)  # VIX > 20 reduces risk
Shares = Adjusted Risk / (2 * ATR)
Position Size = Shares * Price
Capped = min(Position Size, Equity * 5%)
```

## Tests Added

- `TestDynamicPositionSizing`: 6 tests for dynamic sizing logic
- `TestGetStockAtr`: 3 tests for ATR fetching
- All 10 tests pass

## Acceptance Criteria Met

- [x] High ATR stock gets smaller position
- [x] VIX > 30 reduces position size
- [x] ATR unavailable falls back to fixed 5%
- [x] Max position capped at 5%
- [x] All tests pass
- [x] Code is linted and type-checked