### PR TITLE
refactor: Remove commented dead code from candles_to_csv for #85

### DIFF
--- a/src/alpacalyzer/agents/quant_agent.py
+++ b/src/alpacalyzer/agents/quant_agent.py
@@ -110,9 +110,6 @@ def candles_to_csv(df: pd.DataFrame, max_rows: int, granularity: Literal["day", 
             # Keep full ISO format for minute granularity
             df["timestamp"] = df["timestamp"].dt.strftime("%Y-%m-%d %H:%M:%S")
 
-    # Convert to CSV
-    # csv = df.to_csv(index=False)
-    # return cast(str, csv)
     return str(df.to_csv(index=False))
 
 

--- a/src/alpacalyzer/trading/trading_strategist.py
+++ b/src/alpacalyzer/trading/trading_strategist.py
@@ -100,9 +100,6 @@ def candles_to_csv(df: pd.DataFrame, max_rows: int, granularity: Literal["day", 
             # Keep full ISO format for minute granularity
             df["timestamp"] = df["timestamp"].dt.strftime("%Y-%m-%d %H:%M:%S")
 
-    # Convert to CSV
-    # csv = df.to_csv(index=False)
-    # return cast(str, csv)
     return str(df.to_csv(index=False))
 
 


### PR DESCRIPTION
## Summary

Cleaned up commented dead code from the `candles_to_csv()` function in two files.

## Changes

- **Removed commented dead code** (6 lines total) from `candles_to_csv()`:
  - `src/alpacalyzer/trading/trading_strategist.py:103-106`
  - `src/alpacalyzer/agents/quant_agent.py:113-116`

The commented code was dead code that had been replaced by `return str(df.to_csv(index=False))`.

## Verification

- [x] Ruff linting: All checks passed
- [x] Ruff formatting: Applied
- [x] Type checking: Passed
- [x] Tests: 596 passed, 3 skipped

## Checklist

- [x] Code follows project conventions
- [x] No hardcoded credentials
- [x] Tests pass