### PR TITLE
feat(strategies): Add agent integration to BreakoutStrategy

### DIFF
--- a/tests/strategies/test_breakout.py
+++ b/tests/strategies/test_breakout.py
@@ -1131,3 +1131,340 @@ class TestBreakoutStrategyPositionSizing:
         assert decision.entry_price == 98.5
         assert decision.stop_loss > 98.5
         assert decision.target < 98.5
+
+
+class TestBreakoutStrategyAgentIntegration:
+    """
+    Tests for agent recommendation integration (Issue #96).
+
+    Verifies the "agents propose, strategies validate" pattern:
+    - When agent_recommendation provided: use agent's values if conditions valid
+    - When agent_recommendation is None: calculate own values (current behavior)
+    """
+
+    def create_agent_recommendation(
+        self,
+        ticker: str = "TEST",
+        quantity: int = 50,
+        entry_point: float = 101.5,
+        stop_loss: float = 98.0,
+        target_price: float = 108.0,
+        trade_type: str = "long",
+    ):
+        """Create mock TradingStrategy (agent recommendation)."""
+        from alpacalyzer.data.models import TradingStrategy
+
+        return TradingStrategy(
+            ticker=ticker,
+            quantity=quantity,
+            entry_point=entry_point,
+            stop_loss=stop_loss,
+            target_price=target_price,
+            risk_reward_ratio=2.0,
+            strategy_notes="Agent recommendation for breakout",
+            trade_type=trade_type,
+            entry_criteria=[],
+        )
+
+    def test_entry_with_agent_recommendation_uses_agent_values(self):
+        """Test that agent's values are used when conditions are valid."""
+        config = BreakoutConfig(consolidation_periods=10, min_volume_ratio=1.5)
+        strategy = BreakoutStrategy(config)
+
+        # Create valid breakout setup
+        pre_consolidation_prices = [100.0] * 20
+        pre_consolidation_highs = [100.5] * 20
+        pre_consolidation_lows = [99.5] * 20
+        pre_consolidation_volumes = [1_000_000] * 20
+
+        consolidation_prices = [100.0] * 10
+        consolidation_highs = [100.5] * 10
+        consolidation_lows = [99.5] * 10
+        consolidation_volumes = [1_000_000] * 10
+
+        pre_breakout_prices = [100.0] * 1
+        pre_breakout_highs = [100.5] * 1
+        pre_breakout_lows = [99.5] * 1
+        pre_breakout_volumes = [1_000_000] * 1
+
+        breakout_prices = [101.5]
+        breakout_highs = [102.0]
+        breakout_lows = [100.8]
+        breakout_volumes = [2_000_000]
+
+        prices = pre_consolidation_prices + consolidation_prices + pre_breakout_prices + breakout_prices
+        highs = pre_consolidation_highs + consolidation_highs + pre_breakout_highs + breakout_highs
+        lows = pre_consolidation_lows + consolidation_lows + pre_breakout_lows + breakout_lows
+        volumes = pre_consolidation_volumes + consolidation_volumes + pre_breakout_volumes + breakout_volumes
+
+        df = create_mock_data(prices, highs, lows, volumes)
+        signal = create_trading_signals("TEST", 101.5, df)
+
+        context = MarketContext(
+            vix=15.0,
+            market_status="open",
+            account_equity=100000.0,
+            buying_power=50000.0,
+            existing_positions=[],
+            cooldown_tickers=[],
+        )
+
+        # Agent provides specific values
+        agent_rec = self.create_agent_recommendation(
+            ticker="TEST",
+            quantity=75,  # Agent's quantity
+            entry_point=101.5,
+            stop_loss=97.5,  # Agent's stop loss (different from strategy's calculation)
+            target_price=110.0,  # Agent's target (different from strategy's calculation)
+            trade_type="long",
+        )
+
+        decision = strategy.evaluate_entry(signal, context, agent_recommendation=agent_rec)
+
+        assert decision.should_enter is True
+        # Verify agent's values are used, not strategy's calculations
+        assert decision.suggested_size == 75, f"Expected agent's quantity 75, got {decision.suggested_size}"
+        assert decision.entry_price == 101.5, f"Expected agent's entry 101.5, got {decision.entry_price}"
+        assert decision.stop_loss == 97.5, f"Expected agent's stop_loss 97.5, got {decision.stop_loss}"
+        assert decision.target == 110.0, f"Expected agent's target 110.0, got {decision.target}"
+
+    def test_entry_with_agent_recommendation_short_uses_agent_values(self):
+        """Test that agent's values are used for short breakout when conditions valid."""
+        config = BreakoutConfig(consolidation_periods=10, min_volume_ratio=1.5)
+        strategy = BreakoutStrategy(config)
+
+        # Create valid bearish breakout setup
+        pre_consolidation_prices = [100.0] * 20
+        pre_consolidation_highs = [100.5] * 20
+        pre_consolidation_lows = [99.5] * 20
+        pre_consolidation_volumes = [1_000_000] * 20
+
+        consolidation_prices = [100.0] * 10
+        consolidation_highs = [100.5] * 10
+        consolidation_lows = [99.5] * 10
+        consolidation_volumes = [1_000_000] * 10
+
+        breakout_prices = [98.5]
+        breakout_highs = [99.0]
+        breakout_lows = [97.0]
+        breakout_volumes = [2_000_000]
+
+        prices = pre_consolidation_prices + consolidation_prices + breakout_prices
+        highs = pre_consolidation_highs + consolidation_highs + breakout_highs
+        lows = pre_consolidation_lows + consolidation_lows + breakout_lows
+        volumes = pre_consolidation_volumes + consolidation_volumes + breakout_volumes
+
+        df = create_mock_data(prices, highs, lows, volumes)
+        signal = create_trading_signals("TEST", 98.5, df)
+
+        context = MarketContext(
+            vix=15.0,
+            market_status="open",
+            account_equity=100000.0,
+            buying_power=50000.0,
+            existing_positions=[],
+            cooldown_tickers=[],
+        )
+
+        # Agent provides specific values for short
+        agent_rec = self.create_agent_recommendation(
+            ticker="TEST",
+            quantity=60,
+            entry_point=98.5,
+            stop_loss=102.0,  # Agent's stop loss for short
+            target_price=92.0,  # Agent's target for short
+            trade_type="short",
+        )
+
+        decision = strategy.evaluate_entry(signal, context, agent_recommendation=agent_rec)
+
+        assert decision.should_enter is True
+        assert decision.suggested_size == 60
+        assert decision.entry_price == 98.5
+        assert decision.stop_loss == 102.0
+        assert decision.target == 92.0
+
+    def test_entry_with_agent_recommendation_rejects_no_consolidation(self):
+        """Test that entry is rejected when no consolidation pattern exists."""
+        config = BreakoutConfig(consolidation_periods=10, consolidation_range_pct=0.05)
+        strategy = BreakoutStrategy(config)
+
+        # Create non-consolidation data (wide range)
+        prices = [100.0, 105.0, 102.0, 108.0, 101.0, 110.0, 103.0, 112.0, 100.0, 115.0, 116.0, 118.0, 117.0, 119.0, 116.0, 120.0, 118.0, 121.0, 117.0, 122.0, 123.0, 125.0]
+        df = create_mock_data(prices)
+        signal = create_trading_signals("TEST", 125.0, df)
+
+        context = MarketContext(
+            vix=15.0,
+            market_status="open",
+            account_equity=100000.0,
+            buying_power=50000.0,
+            existing_positions=[],
+            cooldown_tickers=[],
+        )
+
+        agent_rec = self.create_agent_recommendation(
+            ticker="TEST",
+            quantity=50,
+            entry_point=125.0,
+            stop_loss=120.0,
+            target_price=135.0,
+            trade_type="long",
+        )
+
+        decision = strategy.evaluate_entry(signal, context, agent_recommendation=agent_rec)
+
+        # Should reject even with agent recommendation
+        assert decision.should_enter is False
+        assert "consolidation" in decision.reason.lower() or "range" in decision.reason.lower()
+
+    def test_entry_with_agent_recommendation_rejects_low_volume(self):
+        """Test that entry is rejected when volume confirmation is missing."""
+        config = BreakoutConfig(consolidation_periods=10, min_volume_ratio=1.5)
+        strategy = BreakoutStrategy(config)
+
+        # Create consolidation with low volume breakout
+        prices = [100.0] * 25 + [101.5]
+        highs = [100.5] * 25 + [102.0]
+        lows = [99.5] * 25 + [100.8]
+        volumes = [1_000_000] * 25 + [1_200_000]  # Only 1.2x volume, below 1.5x threshold
+
+        df = create_mock_data(prices, highs, lows, volumes)
+        signal = create_trading_signals("TEST", 101.5, df)
+
+        context = MarketContext(
+            vix=15.0,
+            market_status="open",
+            account_equity=100000.0,
+            buying_power=50000.0,
+            existing_positions=[],
+            cooldown_tickers=[],
+        )
+
+        agent_rec = self.create_agent_recommendation(
+            ticker="TEST",
+            quantity=50,
+            entry_point=101.5,
+            stop_loss=98.0,
+            target_price=108.0,
+            trade_type="long",
+        )
+
+        decision = strategy.evaluate_entry(signal, context, agent_recommendation=agent_rec)
+
+        # Should reject even with agent recommendation
+        assert decision.should_enter is False
+        assert "volume" in decision.reason.lower()
+
+    def test_entry_without_agent_recommendation_calculates_own_values(self):
+        """Test that strategy calculates own values when no agent recommendation."""
+        config = BreakoutConfig(consolidation_periods=10, min_volume_ratio=1.5)
+        strategy = BreakoutStrategy(config)
+
+        # Create valid breakout setup
+        pre_consolidation_prices = [100.0] * 20
+        pre_consolidation_highs = [100.5] * 20
+        pre_consolidation_lows = [99.5] * 20
+        pre_consolidation_volumes = [1_000_000] * 20
+
+        consolidation_prices = [100.0] * 10
+        consolidation_highs = [100.5] * 10
+        consolidation_lows = [99.5] * 10
+        consolidation_volumes = [1_000_000] * 10
+
+        pre_breakout_prices = [100.0] * 1
+        pre_breakout_highs = [100.5] * 1
+        pre_breakout_lows = [99.5] * 1
+        pre_breakout_volumes = [1_000_000] * 1
+
+        breakout_prices = [101.5]
+        breakout_highs = [102.0]
+        breakout_lows = [100.8]
+        breakout_volumes = [2_000_000]
+
+        prices = pre_consolidation_prices + consolidation_prices + pre_breakout_prices + breakout_prices
+        highs = pre_consolidation_highs + consolidation_highs + pre_breakout_highs + breakout_highs
+        lows = pre_consolidation_lows + consolidation_lows + pre_breakout_lows + breakout_lows
+        volumes = pre_consolidation_volumes + consolidation_volumes + pre_breakout_volumes + breakout_volumes
+
+        df = create_mock_data(prices, highs, lows, volumes)
+        signal = create_trading_signals("TEST", 101.5, df)
+
+        context = MarketContext(
+            vix=15.0,
+            market_status="open",
+            account_equity=100000.0,
+            buying_power=50000.0,
+            existing_positions=[],
+            cooldown_tickers=[],
+        )
+
+        # No agent recommendation - strategy should calculate own values
+        decision = strategy.evaluate_entry(signal, context, agent_recommendation=None)
+
+        assert decision.should_enter is True
+        # Strategy calculates its own values
+        assert decision.suggested_size > 0
+        assert decision.entry_price == 101.5
+        # Stop loss and target are calculated by strategy, not agent
+        assert decision.stop_loss < 101.5  # Below entry for long
+        assert decision.target > 101.5  # Above entry for long
+
+    def test_entry_with_agent_recommendation_rejects_basic_filters(self):
+        """Test that basic filters still apply with agent recommendation."""
+        config = BreakoutConfig(consolidation_periods=10, min_volume_ratio=1.5)
+        strategy = BreakoutStrategy(config)
+
+        prices = [100.0] * 30 + [101.5]
+        df = create_mock_data(prices)
+        signal = create_trading_signals("TEST", 101.5, df)
+
+        # Market closed
+        context = MarketContext(
+            vix=15.0,
+            market_status="closed",
+            account_equity=100000.0,
+            buying_power=50000.0,
+            existing_positions=[],
+            cooldown_tickers=[],
+        )
+
+        agent_rec = self.create_agent_recommendation()
+
+        decision = strategy.evaluate_entry(signal, context, agent_recommendation=agent_rec)
+
+        assert decision.should_enter is False
+        assert "market" in decision.reason.lower()
+
+    def test_entry_with_agent_recommendation_rejects_false_breakouts(self):
+        """Test that false breakout limit still applies with agent recommendation."""
+        config = BreakoutConfig(consolidation_periods=10, min_volume_ratio=1.5, max_false_breakouts=1)
+        strategy = BreakoutStrategy(config)
+
+        # Create valid breakout setup
+        prices = [100.0] * 30 + [101.5]
+        highs = [100.5] * 30 + [102.0]
+        lows = [99.5] * 30 + [100.0]
+        volumes = [1_000_000] * 30 + [2_000_000]
+
+        df = create_mock_data(prices, highs, lows, volumes)
+        signal = create_trading_signals("TEST", 101.5, df)
+
+        context = MarketContext(
+            vix=15.0,
+            market_status="open",
+            account_equity=100000.0,
+            buying_power=50000.0,
+            existing_positions=[],
+            cooldown_tickers=[],
+        )
+
+        # Set false breakout count at limit
+        strategy._false_breakout_count["TEST"] = 1
+
+        agent_rec = self.create_agent_recommendation()
+
+        decision = strategy.evaluate_entry(signal, context, agent_recommendation=agent_rec)
+
+        assert decision.should_enter is False
+        assert "false breakout" in decision.reason.lower()


### PR DESCRIPTION
## Summary

Adds agent recommendation integration to `BreakoutStrategy`, implementing the "agents propose, strategies validate" pattern documented in AGENTS.md.

Closes #96

## Changes

### Implementation (`src/alpacalyzer/strategies/breakout.py`)
- When `agent_recommendation` is provided and breakout conditions are valid:
  - Uses agent's `entry_point`, `stop_loss`, `target_price`, `quantity`
  - Strategy validates conditions but does NOT override agent values
- When `agent_recommendation` is `None`:
  - Strategy operates independently (existing behavior)
  - Calculates own entry/stop/target/size values

### Tests (`tests/strategies/test_breakout.py`)
Added 7 new tests in `TestBreakoutStrategyAgentIntegration`:
- `test_entry_with_agent_recommendation_uses_agent_values` - Long entry uses agent values
- `test_entry_with_agent_recommendation_short_uses_agent_values` - Short entry uses agent values
- `test_entry_with_agent_recommendation_rejects_no_consolidation` - Rejects when no pattern
- `test_entry_with_agent_recommendation_rejects_low_volume` - Rejects when volume low
- `test_entry_without_agent_recommendation_calculates_own_values` - Independent operation
- `test_entry_with_agent_recommendation_rejects_basic_filters` - Market closed rejection
- `test_entry_with_agent_recommendation_rejects_false_breakouts` - False breakout limit

## Acceptance Criteria

- [x] When agent_recommendation provided, strategy uses agent's values
- [x] When agent_recommendation is None, strategy calculates own values
- [x] Tests verify both paths
- [x] Documentation updated

## Test Results

All 37 breakout strategy tests passing, 610 total tests passing.

## Code Review

See `CODE_REVIEW_96.md` - **Approved** with no blocking issues.