### PR TITLE
feat(llm): Add feature flag for LLM client rollback

### DIFF
--- a/src/alpacalyzer/llm/__init__.py
+++ b/src/alpacalyzer/llm/__init__.py
@@ -1,4 +1,61 @@
-from alpacalyzer.llm.client import LLMClient, get_llm_client
-from alpacalyzer.llm.config import LLMTier
+from __future__ import annotations
 
-__all__ = ["LLMClient", "get_llm_client", "LLMTier"]
+import logging
+import os
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from alpacalyzer.llm.client import LLMClient
+from alpacalyzer.llm.client import get_llm_client as _get_new_client
+from alpacalyzer.llm.config import LLMTier
+from alpacalyzer.llm.legacy import legacy_complete_structured
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+_client: LLMClient | None = None
+
+
+def get_llm_client() -> LLMClient:
+    global _client
+    if _client is None:
+        _client = _get_new_client()
+    return _client
+
+
+def use_new_llm() -> bool:
+    """Check if new LLM client is enabled."""
+    return os.getenv("USE_NEW_LLM", "true").lower() == "true"
+
+
+def complete_structured(
+    messages: list[dict],
+    response_model: type[BaseModel],
+    tier: LLMTier = LLMTier.STANDARD,
+) -> BaseModel | None:
+    """
+    Unified interface that routes to new or legacy implementation.
+
+    When USE_NEW_LLM=true (default): Uses new LLMClient with tier routing
+    When USE_NEW_LLM=false: Uses legacy call_gpt_structured
+    """
+    if use_new_llm():
+        client = get_llm_client()
+        result = client.complete_structured(messages, response_model, tier)
+        logger.info(f"LLM call via new client (tier={tier.value})")
+        return result
+    result = legacy_complete_structured(messages, response_model)
+    logger.info("LLM call via legacy call_gpt.py")
+    return result
+
+
+__all__ = [
+    "LLMClient",
+    "get_llm_client",
+    "LLMTier",
+    "use_new_llm",
+    "complete_structured",
+    "legacy_complete_structured",
+]

--- a/src/alpacalyzer/llm/legacy.py
+++ b/src/alpacalyzer/llm/legacy.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
-from alpacalyzer.llm.client import LLMClient
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from alpacalyzer.gpt.call_gpt import call_gpt_structured as _legacy_call
+
+T = TypeVar("T", bound=BaseModel)
 
 
-def get_llm_client() -> LLMClient:
-    return LLMClient()
+def legacy_complete_structured(
+    messages: list[dict],
+    response_model: type[BaseModel],
+) -> BaseModel | None:
+    """Wrapper around legacy call_gpt.py for rollback support."""
+    return _legacy_call(messages, response_model)

--- a/tests/test_llm_feature_flag.py
+++ b/tests/test_llm_feature_flag.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+from alpacalyzer.llm import complete_structured, use_new_llm
+
+
+class TestModel(BaseModel):
+    name: str
+    value: int
+
+
+class TestUseNewLLM:
+    def test_default_true(self, monkeypatch):
+        monkeypatch.delenv("USE_NEW_LLM", raising=False)
+        assert use_new_llm() is True
+
+    def test_explicit_true(self, monkeypatch):
+        monkeypatch.setenv("USE_NEW_LLM", "true")
+        assert use_new_llm() is True
+
+    def test_explicit_false(self, monkeypatch):
+        monkeypatch.setenv("USE_NEW_LLM", "false")
+        assert use_new_llm() is False
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("USE_NEW_LLM", "FALSE")
+        assert use_new_llm() is False
+
+        monkeypatch.setenv("USE_NEW_LLM", "True")
+        assert use_new_llm() is True
+
+
+class TestCompleteStructured:
+    def test_routes_to_new_client_when_flag_true(self, monkeypatch):
+        monkeypatch.setenv("USE_NEW_LLM", "true")
+
+        mock_client = MagicMock()
+        mock_response = TestModel(name="test", value=42)
+        mock_client.complete_structured.return_value = mock_response
+
+        with patch("alpacalyzer.llm.get_llm_client", return_value=mock_client):
+            result = complete_structured(
+                messages=[{"role": "user", "content": "test"}],
+                response_model=TestModel,
+            )
+
+            assert result == mock_response
+            mock_client.complete_structured.assert_called_once()
+
+    def test_routes_to_legacy_when_flag_false(self, monkeypatch):
+        monkeypatch.setenv("USE_NEW_LLM", "false")
+
+        mock_response = TestModel(name="legacy", value=99)
+
+        with patch("alpacalyzer.llm.legacy_complete_structured", return_value=mock_response) as mock_legacy:
+            result = complete_structured(
+                messages=[{"role": "user", "content": "test"}],
+                response_model=TestModel,
+            )
+
+            assert result == mock_response
+            mock_legacy.assert_called_once()


### PR DESCRIPTION
## Summary

Adds a `USE_NEW_LLM` feature flag that allows switching between the new LLM client and the legacy `call_gpt.py` implementation for safe A/B testing and quick rollback.

## Changes

- **`src/alpacalyzer/llm/legacy.py`**: Added `legacy_complete_structured()` wrapper around `call_gpt_structured`
- **`src/alpacalyzer/llm/__init__.py`**: 
  - Added `use_new_llm()` function to check `USE_NEW_LLM` env var
  - Added `complete_structured()` unified interface that routes to new or legacy implementation
  - Added logging for which path is active
- **`tests/test_llm_feature_flag.py`**: Added tests for feature flag behavior

## Environment Variable

```bash
# Enable new LLM client (default)
USE_NEW_LLM=true

# Rollback to legacy implementation
USE_NEW_LLM=false
```

## Acceptance Criteria

- [x] `USE_NEW_LLM=true` uses new LLMClient with tier routing
- [x] `USE_NEW_LLM=false` uses legacy `call_gpt_structured`
- [x] Clear logging indicates which path is active
- [x] All agent tests pass with both settings
- [x] Feature flag can be toggled without restart (reads env var each call)

## Testing

```bash
# Test new implementation
USE_NEW_LLM=true uv run pytest tests/test_llm_feature_flag.py -v

# Test rollback
USE_NEW_LLM=false uv run pytest tests/test_llm_feature_flag.py -v
```