### PR TITLE
docs: Update .env.example and README for new LLM configuration (#111)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,25 +17,30 @@ ALPACA_SECRET_KEY=your_alpaca_secret_key
 OPENAI_API_KEY=your_openai_api_key
 
 # =============================================================================
-# LLM PROVIDER (Optional - defaults to OpenRouter)
+# LLM Configuration (New)
 # =============================================================================
-# Base URL for OpenAI-compatible API (e.g., OpenRouter, Together AI)
+# Feature flag: set to "false" to use legacy OpenAI Responses API
+USE_NEW_LLM=true
+
+# =============================================================================
+# LLM Provider
+# =============================================================================
+# Base URL for OpenAI-compatible API (default: OpenRouter)
 LLM_BASE_URL=https://openrouter.ai/api/v1
 # API key for LLM provider (falls back to OPENAI_API_KEY if not set)
 LLM_API_KEY=
-# Default model for standard completions
-LLM_MODEL_STANDARD=gpt-4o
 
 # =============================================================================
-# LLM MODEL ROUTING (Optional - tier-based model selection)
+# LLM Model Routing (Tier-based model selection)
 # =============================================================================
 # Configure different models for different task complexities
 # FAST: Sentiment classification, opportunity screening (cheap/fast)
 # STANDARD: Investor agents, portfolio allocation (balanced)
 # DEEP: Quant analysis, trading strategist (most capable)
-# LLM_MODEL_FAST=meta-llama/llama-3.2-3b-instruct
-# LLM_MODEL_STANDARD=anthropic/claude-3.5-sonnet
-# LLM_MODEL_DEEP=anthropic/claude-3.5-sonnet
+# Verify model IDs at https://openrouter.ai/models
+LLM_MODEL_FAST=meta-llama/llama-3.2-3b-instruct
+LLM_MODEL_STANDARD=anthropic/claude-3.5-sonnet
+LLM_MODEL_DEEP=anthropic/claude-3.5-sonnet
 
 # =============================================================================
 # OPTIONAL SETTINGS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ cp .env.example .env
 # Edit .env with required API keys:
 # - ALPACA_API_KEY (Alpaca API)
 # - ALPACA_SECRET_KEY (Alpaca secret)
-# - OPENAI_API_KEY (GPT-4)
+# - LLM_API_KEY (OpenAI-compatible LLM provider, e.g., OpenRouter)
+# - USE_NEW_LLM=true (use new LLM abstraction layer)
 
 # 3. Start development
 uv run alpacalyzer --analyze  # Analysis mode (no real trades)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,47 @@ LOG_LEVEL=INFO
 
 ---
 
+## LLM Configuration
+
+Alpacalyzer supports multiple LLM providers via OpenAI-compatible APIs.
+
+### Quick Start (OpenRouter)
+
+1. Get an API key from [OpenRouter](https://openrouter.ai)
+2. Set in `.env`:
+   ```
+   LLM_API_KEY=your_openrouter_key
+   ```
+
+### Model Tiers
+
+Different agents use different model tiers based on task complexity:
+
+| Tier     | Agents                             | Default Model     |
+| -------- | ---------------------------------- | ----------------- |
+| Fast     | Sentiment, Opportunity Finder      | Llama 3.2 3B      |
+| Standard | Investor Agents, Portfolio Manager | Claude 3.5 Sonnet |
+| Deep     | Quant Agent, Trading Strategist    | Claude 3.5 Sonnet |
+
+Override defaults via environment variables:
+
+```
+LLM_MODEL_FAST=meta-llama/llama-3.2-3b-instruct
+LLM_MODEL_STANDARD=anthropic/claude-3.5-sonnet
+LLM_MODEL_DEEP=anthropic/claude-3.5-sonnet
+```
+
+### Rollback to OpenAI
+
+To use the legacy OpenAI implementation:
+
+```
+USE_NEW_LLM=false
+OPENAI_API_KEY=your_openai_key
+```
+
+---
+
 ## Usage
 
 ### Analysis Mode (No Trades)


### PR DESCRIPTION
## Summary

Updates documentation and environment example files to reflect the new LLM configuration options per issue #111.

### Changes Made

- **`.env.example`**: Added `USE_NEW_LLM` feature flag, reorganized LLM configuration sections, added all three model tier entries (`LLM_MODEL_FAST`, `LLM_MODEL_STANDARD`, `LLM_MODEL_DEEP`) with OpenRouter links

- **`README.md`**: Added "LLM Configuration" section with:
  - Quick start instructions for OpenRouter
  - Model tiers table showing agents and default models
  - Rollback instructions for legacy OpenAI implementation

- **`AGENTS.md`**: Updated Quick Start section with new `LLM_API_KEY` and `USE_NEW_LLM=true` env vars

### Acceptance Criteria Met

- [x] `.env.example` has all new LLM env vars with comments
- [x] `README.md` has LLM configuration section
- [x] `AGENTS.md` Quick Start updated
- [x] All env var names consistent across docs
- [x] Links to OpenRouter models page included

### Related

- Part of Iteration 1: LLM Abstraction Layer
- Depends on #4 (agent migration complete)