### PR TITLE
feat(agents): convert candle data to markdown tables for #124

### DIFF
--- a/src/alpacalyzer/agents/quant_agent.py
+++ b/src/alpacalyzer/agents/quant_agent.py
@@ -1,7 +1,6 @@
 import json
 from typing import Literal
 
-import pandas as pd
 from langchain_core.messages import HumanMessage
 from pydantic import BaseModel
 
@@ -9,6 +8,7 @@ from alpacalyzer.analysis.technical_analysis import TechnicalAnalyzer, TradingSi
 from alpacalyzer.graph.state import AgentState, show_agent_reasoning
 from alpacalyzer.llm import LLMTier, get_llm_client
 from alpacalyzer.prompts import load_prompt
+from alpacalyzer.utils.candles_formatter import format_candles_to_markdown
 from alpacalyzer.utils.progress import progress
 
 
@@ -80,45 +80,6 @@ def quant_agent(state: AgentState):
     return {"messages": [message], "data": state["data"]}
 
 
-def candles_to_csv(df: pd.DataFrame, max_rows: int, granularity: Literal["day", "minute"] = "minute") -> str:
-    """Convert a DataFrame of candle data to a compact CSV format with explicit units."""
-
-    # Keep only the most recent `max_rows`
-    df = df.tail(max_rows).copy()
-
-    # Rename "symbol" to "ticker" if present
-    if "symbol" in df.columns:
-        df = df.rename(columns={"symbol": "ticker"})
-
-    # Define required columns, include ticker if available
-    required_cols = ["timestamp", "open", "high", "low", "close", "volume"]
-    if "ticker" in df.columns:
-        required_cols.append("ticker")
-
-    # Filter columns (only if they exist)
-    df = df[[col for col in required_cols if col in df.columns]]
-
-    # Round and add units to price columns
-    for col in ["open", "high", "low", "close"]:
-        if col in df.columns:
-            df[col] = df[col].apply(lambda x: f"${round(x, 2):.2f}" if pd.notna(x) else "")
-
-    # Add units to volume (comma-formatted with "shares" suffix)
-    if "volume" in df.columns:
-        df["volume"] = df["volume"].apply(lambda x: f"{int(x):,} shares" if pd.notna(x) else "")
-
-    # Adjust timestamp based on granularity
-    if "timestamp" in df.columns:
-        df["timestamp"] = pd.to_datetime(df["timestamp"])
-        if granularity == "day":
-            # Keep only the date part
-            df["timestamp"] = df["timestamp"].dt.strftime("%Y-%m-%d")
-        elif granularity == "minute":
-            # Keep full ISO format for minute granularity
-            df["timestamp"] = df["timestamp"].dt.strftime("%Y-%m-%d %H:%M:%S")
-
-    return str(df.to_csv(index=False))
-
 
 def serialize_trading_signals(signals: TradingSignals) -> str:
     """Convert TradingSignals object into a JSON-compatible format with explicit units."""
@@ -152,8 +113,8 @@ def get_quant_analysis(
     )
 
     signals_str = serialize_trading_signals(trading_signals)
-    candles_3_months_str = candles_to_csv(trading_signals["raw_data_daily"], max_rows=90, granularity="day")
-    candles_5_min_str = candles_to_csv(trading_signals["raw_data_intraday"], max_rows=120, granularity="minute")
+    candles_3_months_str = format_candles_to_markdown(trading_signals["raw_data_daily"], max_rows=90, granularity="day")
+    candles_5_min_str = format_candles_to_markdown(trading_signals["raw_data_intraday"], max_rows=120, granularity="minute")
 
     human_message = {
         "role": "user",

--- a/src/alpacalyzer/utils/candles_formatter.py
+++ b/src/alpacalyzer/utils/candles_formatter.py
@@ -1,0 +1,54 @@
+from typing import Literal
+
+import pandas as pd
+
+
+def format_candles_to_markdown(
+    df: pd.DataFrame,
+    max_rows: int,
+    granularity: Literal["day", "minute"] = "minute",
+) -> str:
+    """
+    Convert a DataFrame of candle data to a markdown table format.
+
+    Args:
+        df: DataFrame with candle data (must have timestamp, open, high, low, close, volume)
+        max_rows: Maximum number of rows to include (most recent candles)
+        granularity: "day" for date-only, "minute" for full timestamp
+
+    Returns:
+        Markdown table string with formatted prices ($) and volumes (commas)
+    """
+    if df is None or df.empty:
+        header = "| Date | Open | High | Low | Close | Volume |"
+        separator = "|------|------|------|-----|-------|--------|"
+        return f"{header}\n{separator}"
+
+    df = df.tail(max_rows).copy()
+
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        if granularity == "day":
+            df["Date"] = df["timestamp"].dt.strftime("%Y-%m-%d")
+        elif granularity == "minute":
+            df["Date"] = df["timestamp"].dt.strftime("%Y-%m-%d %H:%M:%S")
+
+    required_cols = ["Date", "open", "high", "low", "close", "volume"]
+    df = df[[col for col in required_cols if col in df.columns]]
+
+    df["Open"] = df["open"].apply(lambda x: f"${x:.2f}")
+    df["High"] = df["high"].apply(lambda x: f"${x:.2f}")
+    df["Low"] = df["low"].apply(lambda x: f"${x:.2f}")
+    df["Close"] = df["close"].apply(lambda x: f"${x:.2f}")
+    df["Volume"] = df["volume"].apply(lambda x: f"{int(x):,}")
+
+    df = df.drop(columns=["open", "high", "low", "close", "volume"], errors="ignore")
+
+    header = "| " + " | ".join(df.columns) + " |"
+    separator = "|" + "|".join([" --- " for _ in df.columns]) + "|"
+
+    rows = []
+    for _, row in df.iterrows():
+        rows.append("| " + " | ".join(str(v) for v in row.values) + " |")
+
+    return "\n".join([header, separator] + rows)

--- a/tests/test_candles_formatter.py
+++ b/tests/test_candles_formatter.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+from alpacalyzer.utils.candles_formatter import format_candles_to_markdown
+
+
+@pytest.fixture
+def daily_df():
+    data = {
+        "timestamp": [datetime(2026, 2, 10), datetime(2026, 2, 11), datetime(2026, 2, 12)],
+        "open": [150.2, 151.5, 152.8],
+        "high": [152.1, 153.0, 154.2],
+        "low": [149.8, 150.9, 151.5],
+        "close": [151.5, 152.8, 153.5],
+        "volume": [1234567, 987654, 1500000],
+    }
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def intraday_df():
+    data = {
+        "timestamp": [
+            datetime(2026, 2, 12, 9, 30),
+            datetime(2026, 2, 12, 10, 30),
+            datetime(2026, 2, 12, 11, 30),
+        ],
+        "open": [153.5, 154.0, 154.5],
+        "high": [154.2, 155.0, 155.5],
+        "low": [153.0, 153.5, 154.0],
+        "close": [154.0, 154.8, 155.2],
+        "volume": [50000, 75000, 60000],
+    }
+    return pd.DataFrame(data)
+
+
+class TestFormatCandlesToMarkdown:
+    def test_daily_candles_formatted_correctly(self, daily_df):
+        result = format_candles_to_markdown(daily_df, max_rows=3, granularity="day")
+
+        assert "| Date | Open | High | Low | Close | Volume |" in result
+        assert "| --- | --- | --- | --- | --- | --- |" in result
+        assert "| 2026-02-10 | $150.20 | $152.10 | $149.80 | $151.50 | 1,234,567 |" in result
+        assert "| 2026-02-11 | $151.50 | $153.00 | $150.90 | $152.80 | 987,654 |" in result
+        assert "| 2026-02-12 | $152.80 | $154.20 | $151.50 | $153.50 | 1,500,000 |" in result
+
+    def test_intraday_candles_formatted_correctly(self, intraday_df):
+        result = format_candles_to_markdown(intraday_df, max_rows=3, granularity="minute")
+
+        assert "| Date | Open | High | Low | Close | Volume |" in result
+        assert "| --- | --- | --- | --- | --- | --- |" in result
+        assert "| 2026-02-12 09:30:00 | $153.50 | $154.20 | $153.00 | $154.00 | 50,000 |" in result
+        assert "| 2026-02-12 10:30:00 | $154.00 | $155.00 | $153.50 | $154.80 | 75,000 |" in result
+
+    def test_max_rows_limits_output(self, daily_df):
+        result = format_candles_to_markdown(daily_df, max_rows=2, granularity="day")
+
+        lines = result.strip().split("\n")
+        data_lines = [line for line in lines if line.startswith("|") and "$" in line]
+        assert len(data_lines) == 2
+
+    def test_prices_have_dollar_sign(self, daily_df):
+        result = format_candles_to_markdown(daily_df, max_rows=1, granularity="day")
+
+        assert "$152.80" in result
+        assert "$154.20" in result
+
+    def test_volumes_have_commas(self, daily_df):
+        result = format_candles_to_markdown(daily_df, max_rows=1, granularity="day")
+
+        assert "1,500,000" in result
+
+    def test_empty_dataframe_returns_headers_only(self):
+        df = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
+        result = format_candles_to_markdown(df, max_rows=10, granularity="day")
+
+        assert "| Date | Open | High | Low | Close | Volume |" in result
+        assert "|------|------|------|-----|-------|--------|" in result
+
+    def test_rounding_to_2_decimal_places(self, daily_df):
+        result = format_candles_to_markdown(daily_df, max_rows=1, granularity="day")
+
+        assert "$152.80" in result
+        assert "$154.20" in result
+        assert "$151.50" in result
+        assert "$153.50" in result


### PR DESCRIPTION
## Summary
- Created a new utility function `format_candles_to_markdown()` in `src/alpacalyzer/utils/candles_formatter.py` that converts OHLCV candle data to markdown tables
- Updated `quant_agent.py` and `trading_strategist.py` to use markdown tables instead of CSV format for better LLM comprehension
- Prices are formatted with `$` prefix and volumes with comma separators
- Maintained the same max_rows limits (90 for daily, 120 for minute) to avoid significant token usage increase

## Changes
- Added `src/alpacalyzer/utils/candles_formatter.py` - utility function for markdown table conversion
- Added `tests/test_candles_formatter.py` - 7 tests covering the new utility function
- Modified `src/alpacalyzer/agents/quant_agent.py` - replaced `candles_to_csv` with `format_candles_to_markdown`
- Modified `src/alpacalyzer/trading/trading_strategist.py` - replaced `candles_to_csv` with `format_candles_to_markdown`

Closes #124