### PR TITLE
feat(ta): add trade count confirmation signal for #133

### DIFF
--- a/src/alpacalyzer/analysis/technical_analysis.py
+++ b/src/alpacalyzer/analysis/technical_analysis.py
@@ -459,6 +459,18 @@ class TechnicalAnalyzer:
             elif rvol_intraday < 0.7:
                 signals["raw_score"] -= 20
 
+            # 5. Trade Count Confirmation (high trade count = high conviction)
+            # Compare current trade_count to average over lookback period
+            trade_count = latest_intraday.get("trade_count")
+            if trade_count is not None and intraday_df is not None and len(intraday_df) >= 20:
+                avg_trade_count = intraday_df["trade_count"].iloc[-20:].mean()
+                if avg_trade_count > 0:
+                    trade_count_ratio = trade_count / avg_trade_count
+                    if trade_count_ratio > 1.5:
+                        # High trade count indicates strong conviction
+                        signals["raw_score"] += 15
+                        signals["signals"].append(f"TA: High trade count confirmation ({trade_count:.0f} > 1.5x avg {avg_trade_count:.0f})")
+
         ### --- NORMALIZATION --- ###
         min_raw_score, max_raw_score = -130, 180
         signals["score"] = (signals["raw_score"] - min_raw_score) / (max_raw_score - min_raw_score)


### PR DESCRIPTION
## Summary
- Add trade_count field to test fixtures
- Implement trade_count confirmation signal in technical analysis (high trade count = high conviction)
- When current trade_count > 1.5x average over 20-period lookback, adds +15 to raw score

## Test plan
- [x] All existing tests pass
- [x] New trade_count_confirmation_signal test passes
- [x] Linting passes
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)