### PR TITLE
feat(agents): Migrate skills from `.claude/skills/` to `.agents/skills/` for #138

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,7 +387,7 @@ from alpacalyzer.strategies.base import BaseStrategy
 
 ## 📚 Common Tasks & Skills
 
-For detailed step-by-step procedures, see skill files in `.claude/skills/`:
+For detailed step-by-step procedures, see skill files in `.agents/skills/` (symlinked from `.claude/skills/`):
 
 | Task                        | Skill File                     | When to Use                                                   |
 | --------------------------- | ------------------------------ | ------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ uv run ruff check . && uv run ruff format . && uv run ty check src
 See [AGENTS.md](AGENTS.md) for comprehensive development guidelines including:
 
 - Test-driven development workflow
-- Skill files for common tasks (`.claude/skills/`)
+- Skill files for common tasks (`.agents/skills/`)
 - Code review instructions
 - Worktree management for parallel development
 


### PR DESCRIPTION
## Summary
- Created symlinks from `.claude/skills/*` → `.agents/skills/*` using existing setup script
- Updated AGENTS.md and README.md to reference `.agents/skills/` as the source of truth
- All 7 skills now properly symlinked: execution, gpt-integration, new-agent, new-scanner, new-strategy, pydantic-model, technical-indicator

Closes #138