### PR TITLE
feat(agents): migrate code-reviewer to .agents/agents/ with per-tool frontmatter for #139

### DIFF
--- a/.agents/agents/code-reviewer/claude.md
+++ b/.agents/agents/code-reviewer/claude.md
@@ -1,7 +1,0 @@
----
-name: code-reviewer
-description: Reviews PR code changes for quality, tests, and Alpacalyzer conventions. Use after creating a PR or when requesting code review.
-permissionMode: bypassPermissions
----
-
-{{ #include .agents/agents/code-reviewer/prompt.md }}

--- a/.agents/agents/code-reviewer/opencode.md
+++ b/.agents/agents/code-reviewer/opencode.md
@@ -1,6 +1,0 @@
----
-name: code-reviewer
-description: Reviews PR code changes for quality, tests, and Alpacalyzer conventions. Use after creating a PR or when requesting code review.
----
-
-See `.agents/agents/code-reviewer/prompt.md` for the full review instructions.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,1 +1,7 @@
-../../.agents/agents/code-reviewer/claude.md
+---
+name: code-reviewer
+description: Reviews PR code changes for quality, tests, and Alpacalyzer conventions. Use after creating a PR or when requesting code review.
+permissionMode: bypassPermissions
+---
+
+{{ #include .agents/agents/code-reviewer/prompt.md }}

--- a/.opencode/agent/code-reviewer.md
+++ b/.opencode/agent/code-reviewer.md
@@ -1,1 +1,6 @@
-../../.agents/agents/code-reviewer/opencode.md
+---
+name: code-reviewer
+description: Reviews PR code changes for quality, tests, and Alpacalyzer conventions. Use after creating a PR or when requesting code review.
+---
+
+See `.agents/agents/code-reviewer/prompt.md` for the full review instructions.


### PR DESCRIPTION
## Summary
- Created `.agents/agents/code-reviewer/prompt.md` with shared review instructions (no frontmatter)
- Created `.agents/agents/code-reviewer/claude.md` with Claude Code frontmatter + include of prompt.md
- Created `.agents/agents/code-reviewer/opencode.md` with OpenCode frontmatter (full prompt since includes aren't supported)
- Created symlinks: `.claude/agents/code-reviewer.md` → `.agents/agents/code-reviewer/claude.md`
- Created symlinks: `.opencode/agent/code-reviewer.md` → `.agents/agents/code-reviewer/opencode.md`
- Removed old `.agents/agents/code-reviewer.md` file

This eliminates duplication - now there's a single source of truth for the review instructions in `prompt.md`, with tool-specific frontmatter in `claude.md` and `opencode.md`.